### PR TITLE
chore: clean up docs and add version to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Atlas now reads `CLAUDE.md` from project root (if exists) for project configuration
   - No separate configuration file needed—uses the same file Claude Code uses
   - If no `CLAUDE.md` exists, Atlas works without it (CC analyzes project automatically)
+- Cleaned up unnecessary output messages during `atlas init`
+- Added version number to README.md header
+- Updated contributing guidelines in CLAUDE.md (changelog + version updates)
 
 ### Removed
 - `templates/project-rules.txt` template file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,15 +112,6 @@ Completed tasks with dates and PR links.
 ## TODO → ## IN PROGRESS → ## DONE
 ```
 
-## Project Configuration
-
-Atlas reads the project's `CLAUDE.md` file (if it exists) for project-specific
-configuration. This is the same file used by Claude Code, so there's no extra
-configuration needed—Atlas automatically uses what you already have.
-
-If your project doesn't have a `CLAUDE.md`, Atlas will work without it. Claude Code
-will analyze the project structure automatically.
-
 ## Quality Checklist
 
 Atlas enforces these checks before accepting `READY_TO_MERGE`:
@@ -241,9 +232,13 @@ After modifying `atlas.sh`:
 
 ## Contributing
 
-**IMPORTANT**: For every change made to this project, you MUST update `CHANGELOG.md`:
+**IMPORTANT**: For every change made to this project:
 
-1. Add your changes under the `[Unreleased]` section
-2. Use the appropriate category: Added, Changed, Deprecated, Removed, Fixed, Security
-3. When releasing, move unreleased changes to a new version section with date
-4. Follow [Keep a Changelog](https://keepachangelog.com/) format
+1. **CHANGELOG.md**: Add changes under `[Unreleased]` section
+   - Use categories: Added, Changed, Deprecated, Removed, Fixed, Security
+   - Follow [Keep a Changelog](https://keepachangelog.com/) format
+
+2. **When releasing a new version**:
+   - Move `[Unreleased]` changes to a new version section with date
+   - Update `VERSION` in `atlas.sh` (line ~18)
+   - Update version badge/number in `README.md` if displayed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center">
   <h1 align="center">ATLAS</h1>
   <p align="center"><strong>Autonomous Task Loop Agent System</strong></p>
+  <p align="center">v1.0.1</p>
   <p align="center">
     <em>Let Claude Code work through your backlog while you focus on what matters</em>
   </p>

--- a/atlas.sh
+++ b/atlas.sh
@@ -719,14 +719,6 @@ do_init() {
     echo -e "${GREEN}✓${NC} Created backlog.md"
     echo -e "${GREEN}✓${NC} Created progress.txt"
     echo -e "${GREEN}✓${NC} Created logs/"
-
-    # Check for CLAUDE.md
-    if [[ -f "$PROJECT_CLAUDE_MD" ]]; then
-        echo -e "${GREEN}✓${NC} Found CLAUDE.md (will use for project context)"
-    else
-        echo -e "${YELLOW}!${NC} No CLAUDE.md found (Atlas will analyze project on first run)"
-    fi
-
     echo ""
     echo -e "${BOLD}${GREEN}Atlas initialized successfully!${NC}"
     echo ""


### PR DESCRIPTION
## Summary
- Remove redundant "Project Configuration" section from CLAUDE.md
- Remove unnecessary CLAUDE.md message from atlas.sh do_init function
- Update Contributing section in CLAUDE.md with versioning instructions
- Add version v1.0.1 to README.md header
- Document all changes in CHANGELOG.md

## Type
Chore (documentation and code cleanup)

## Testing
- Verified documentation reads correctly
- No functional changes to codebase