### PR TITLE
[Chore]: Remove dead code and add no-git project support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `templates/project-rules.txt` template file
 - `PROJECT_RULES_FILE` validation (no longer required)
+- Unused `is_git_repo()` function (dead code)
+
+### Fixed
+- Atlas now works on projects without git (skips git/branch/PR operations)
 
 ---
 

--- a/atlas-rules.txt
+++ b/atlas-rules.txt
@@ -7,6 +7,9 @@ Read carefully and follow ALL rules precisely.
 IMPORTANT: Read the project's CLAUDE.md (if provided) for project-specific
 configuration (how to run the project, testing strategy, code style, etc.)
 
+NOTE: If the project has no git repository initialized, skip all git/branch/PR
+operations and simply implement the changes directly. Don't stop working.
+
 ===============================================================================
 SECTION 1: ITERATION MODES
 ===============================================================================

--- a/atlas.sh
+++ b/atlas.sh
@@ -249,10 +249,6 @@ get_total_count() {
     fi
 }
 
-is_git_repo() {
-    git rev-parse --git-dir > /dev/null 2>&1
-}
-
 save_state() {
     cat > "$STATE_FILE" << EOF
 {


### PR DESCRIPTION
## Summary
- Removed unused `is_git_repo()` function from `atlas.sh` (dead code cleanup)
- Added note in `atlas-rules.txt` to handle projects without git initialization
- Updated `CHANGELOG.md` with all changes

## Changes
1. **atlas.sh**: Deleted `is_git_repo()` function (lines 252-255) - never called anywhere
2. **atlas-rules.txt**: Added guidance for Claude to skip git operations in non-git projects
3. **CHANGELOG.md**: Documented under Removed and Fixed sections

## Impact
- Cleaner codebase (removed unused code)
- Atlas can now work on projects without git repositories
- No breaking changes