### PR TITLE
feat: add GitHub Action for automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from atlas.sh
+        id: version
+        run: |
+          VERSION=$(grep '^VERSION=' atlas.sh | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        if: steps.check_tag.outputs.exists == 'false'
+        id: changelog
+        run: |
+          # Extract the section for this version from CHANGELOG.md
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Get content between this version header and the next version header (or end)
+          NOTES=$(awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+
+          # If no specific version section, use Unreleased
+          if [ -z "$NOTES" ]; then
+            NOTES=$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
+          fi
+
+          # Write to file for multiline support
+          echo "$NOTES" > release_notes.md
+
+      - name: Create Release
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- GitHub Action for automatic releases on merge to main
+  - Reads VERSION from atlas.sh
+  - Creates git tag if doesn't exist
+  - Creates GitHub Release with notes from CHANGELOG
+
 ---
 
 ## [1.1.0] - 2026-01-09

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,19 +261,21 @@ Follow **Semantic Versioning** (MAJOR.MINOR.PATCH):
 - **MINOR** (1.0.0 → 1.1.0): New features (backwards compatible)
 - **PATCH** (1.0.0 → 1.0.1): Bug fixes only
 
-**Release checklist**:
-1. Move `[Unreleased]` section to new version with date
+**Release checklist** (in a single PR):
+1. Move `[Unreleased]` section to new version with date:
    ```markdown
    ## [1.2.0] - 2026-01-15
    ```
 2. Update `VERSION` in `atlas.sh` (line ~18): `VERSION="1.2.0"`
-3. Update version badge in `README.md`: `v1.2.0`
-4. Create git tag: `git tag v1.2.0`
-5. Create PR with release changes
-6. After merge, push tag: `git push origin v1.2.0`
+3. Update version in `README.md` header: `v1.2.0`
+4. Merge PR to main
+
+**Automatic release**: After merge, GitHub Action (`.github/workflows/release.yml`) will:
+- Detect the new VERSION
+- Create git tag `v1.2.0`
+- Create GitHub Release with notes from CHANGELOG
 
 **Important**: Version number must match across:
 - `atlas.sh` (VERSION variable)
 - `CHANGELOG.md` (release section)
 - `README.md` (display badge)
-- Git tags (v1.2.0)


### PR DESCRIPTION
## Summary
- Adds GitHub Action workflow that automatically creates releases on merge to main
- Reads VERSION from atlas.sh, creates tag and release with CHANGELOG notes
- Updates documentation in CLAUDE.md with new release process

## Test plan
- Merge this PR
- Future version bumps will automatically create releases