### PR TITLE
fix: add streaming mode error to retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Creates git tag if doesn't exist
   - Creates GitHub Release with notes from CHANGELOG
 
+### Fixed
+- Retry logic now also handles "streaming mode" CLI errors (not just lock conflicts)
+  - These transient errors occur intermittently in non-interactive mode
+  - Same exponential backoff (2s, 4s, 8s) applies
+
 ---
 
 ## [1.1.0] - 2026-01-09

--- a/atlas.sh
+++ b/atlas.sh
@@ -139,8 +139,8 @@ get_timeout_cmd() {
 
 TIMEOUT_CMD=$(get_timeout_cmd)
 
-# Run Claude with retry logic for lock acquisition errors
-# This handles the case where multiple Claude Code sessions compete for the version lock
+# Run Claude with retry logic for transient errors
+# Handles: lock conflicts, streaming mode errors, and other CLI startup issues
 run_claude_with_retry() {
     local log_file="$1"
     shift  # Remove log_file from arguments, rest are claude args
@@ -157,20 +157,22 @@ run_claude_with_retry() {
             claude "$@" > "$log_file" 2>&1 || true
         fi
 
-        # Check if it's a lock error
-        if grep -q "Lock acquisition failed" "$log_file" 2>/dev/null; then
+        # Check for transient errors that should trigger retry
+        # - Lock acquisition failed: multiple CC sessions competing
+        # - streaming mode: CLI startup issue in non-interactive mode
+        if grep -qE "Lock acquisition failed|streaming mode" "$log_file" 2>/dev/null; then
             if [[ $attempt -lt $max_retries ]]; then
-                echo -e "    ${YELLOW}↻ Lock conflict detected, retrying in ${retry_delay}s... (attempt $((attempt+1))/$max_retries)${NC}"
+                echo -e "    ${YELLOW}↻ CLI error detected, retrying in ${retry_delay}s... (attempt $((attempt+1))/$max_retries)${NC}"
                 sleep $retry_delay
                 retry_delay=$((retry_delay * 2))  # Exponential backoff: 2s, 4s, 8s
                 attempt=$((attempt + 1))
                 continue
             else
-                echo -e "    ${RED}⚠ Lock conflict persists after $max_retries attempts${NC}"
+                echo -e "    ${RED}⚠ CLI error persists after $max_retries attempts${NC}"
             fi
         fi
 
-        # Success or non-lock error, exit loop
+        # Success or non-retryable error, exit loop
         break
     done
 }


### PR DESCRIPTION
## Summary
- Extended retry logic to handle 'streaming mode' CLI errors
- These errors occur intermittently when Claude Code starts in non-interactive mode
- Uses same exponential backoff (2s, 4s, 8s) as lock errors

## Test plan
- Run Atlas when CLI has transient startup issues
- Verify retry kicks in with exponential backoff