### PR TITLE
release: v1.2.0 - silent retry and release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.2.0] - 2026-01-09
+
 ### Added
 - GitHub Action for automatic releases on merge to main
   - Reads VERSION from atlas.sh
   - Creates git tag if doesn't exist
   - Creates GitHub Release with notes from CHANGELOG
+
+### Changed
+- Silent retry for transient CLI errors (no user-visible messages unless all retries fail)
+  - Previously showed "CLI error detected, retrying..." on each attempt
+  - Now silently retries and only shows error after 3 failed attempts
 
 ### Fixed
 - Retry logic now also handles "streaming mode" CLI errors (not just lock conflicts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,3 +279,18 @@ Follow **Semantic Versioning** (MAJOR.MINOR.PATCH):
 - `atlas.sh` (VERSION variable)
 - `CHANGELOG.md` (release section)
 - `README.md` (display badge)
+
+### 3. Before merging to main (CRITICAL)
+**ALWAYS check before creating a PR to main:**
+
+1. Read `CHANGELOG.md` and check if `[Unreleased]` section has content
+2. If `[Unreleased]` is NOT empty:
+   - Ask the user: "Hay cambios en [Unreleased]. ¿Querés que cree una release?"
+   - If YES: Follow the release checklist (step 2 above)
+   - If NO: Proceed without creating release (content stays in [Unreleased])
+3. If `[Unreleased]` IS empty: Proceed normally
+
+**Why this matters**: Merging changes to main without creating a release means:
+- VERSION stays the same → GitHub Action won't create a new release
+- Changes are in main but not in any release
+- Users running `atlas update` won't get the changes until next release

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <h1 align="center">ATLAS</h1>
   <p align="center"><strong>Autonomous Task Loop Agent System</strong></p>
-  <p align="center">v1.1.0</p>
+  <p align="center">v1.2.0</p>
   <p align="center">
     <em>Let Claude Code work through your backlog while you focus on what matters</em>
   </p>

--- a/atlas.sh
+++ b/atlas.sh
@@ -15,7 +15,7 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 SCRIPT_NAME="atlas"
-VERSION="1.1.0"
+VERSION="1.2.0"
 
 # Detect ATLAS_HOME (where atlas is installed globally)
 if [[ -f "$HOME/.atlas-home" ]]; then
@@ -162,12 +162,13 @@ run_claude_with_retry() {
         # - streaming mode: CLI startup issue in non-interactive mode
         if grep -qE "Lock acquisition failed|streaming mode" "$log_file" 2>/dev/null; then
             if [[ $attempt -lt $max_retries ]]; then
-                echo -e "    ${YELLOW}↻ CLI error detected, retrying in ${retry_delay}s... (attempt $((attempt+1))/$max_retries)${NC}"
+                # Silent retry - don't bother user with transient errors
                 sleep $retry_delay
                 retry_delay=$((retry_delay * 2))  # Exponential backoff: 2s, 4s, 8s
                 attempt=$((attempt + 1))
                 continue
             else
+                # Only show error if all retries failed
                 echo -e "    ${RED}⚠ CLI error persists after $max_retries attempts${NC}"
             fi
         fi


### PR DESCRIPTION
## Summary
- Silent retry for transient CLI errors - no user-visible messages unless all 3 retries fail
- Add release workflow instructions to CLAUDE.md (check [Unreleased] before merging to main)
- Includes GitHub Action for auto-releases and "streaming mode" error handling from [Unreleased]

## Changes
- `atlas.sh`: VERSION="1.2.0", removed echo in retry loop
- `CHANGELOG.md`: Moved [Unreleased] to [1.2.0]
- `README.md`: v1.2.0
- `CLAUDE.md`: Added "Before merging to main" checklist

## Test plan
- [x] VERSION updated in atlas.sh
- [x] CHANGELOG has [1.2.0] section with date
- [x] README shows v1.2.0
- [x] [Unreleased] section is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)