### PR TITLE
feat: add iteration timeout and stale task recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,29 @@ atlas [command] [options]
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ATLAS_MAX_ITERATIONS` | Default max iterations | 10 |
-| `ATLAS_STALE_SECONDS` | Reset stuck stories after N seconds | 0 (disabled) |
+| `ATLAS_MAX_ITERATIONS` | Max iterations per run | 10 |
+| `ATLAS_TIMEOUT` | Timeout per iteration (seconds) | 1200 (20 min) |
+| `ATLAS_STALE_SECONDS` | Reset stuck tasks after N seconds | 7200 (2 hours) |
 | `ATLAS_NOTIFY_TELEGRAM` | Enable Telegram notifications | true |
 | `ATLAS_TELEGRAM_BOT` | Telegram bot token | - |
 | `ATLAS_TELEGRAM_CHAT` | Telegram chat ID | - |
+
+### Timeout
+
+Each iteration has a 20-minute timeout by default. If Claude hangs, the iteration is killed and the next one starts.
+
+```bash
+ATLAS_TIMEOUT=600 atlas 10   # 10 min timeout per iteration
+```
+
+### Stale Task Recovery
+
+If a task is stuck in `IN PROGRESS` for more than 2 hours (default), it's automatically moved back to `TODO` on the next run. This handles crashes or interrupted sessions.
+
+```bash
+ATLAS_STALE_SECONDS=3600 atlas 10  # Reset after 1 hour
+ATLAS_STALE_SECONDS=0 atlas 10     # Disable stale detection
+```
 
 ---
 

--- a/atlas.sh
+++ b/atlas.sh
@@ -7,7 +7,8 @@ PROJECT_NAME="$(basename "$PROJECT_DIR")"
 NOTIFY_TELEGRAM="${ATLAS_NOTIFY_TELEGRAM:-true}"
 
 DEFAULT_MAX_ITERATIONS=10
-DEFAULT_STALE_SECONDS=0
+DEFAULT_STALE_SECONDS=7200
+DEFAULT_TIMEOUT=1200
 
 ATLAS_DIR=".atlas"
 RUNS_DIR="$ATLAS_DIR/runs"
@@ -70,14 +71,16 @@ case "${1:-}" in
         echo "       atlas 25      - Run 25 iterations"
         echo ""
         echo "Environment:"
-        echo "  ATLAS_STALE_SECONDS=3600    Reset stuck stories"
-        echo "  ATLAS_NOTIFY_TELEGRAM=false Disable Telegram"
+        echo "  ATLAS_TIMEOUT=1200          Iteration timeout in seconds (default: 1200 = 20min)"
+        echo "  ATLAS_STALE_SECONDS=7200    Reset stuck tasks after N seconds (default: 7200 = 2h)"
+        echo "  ATLAS_NOTIFY_TELEGRAM=false Disable Telegram notifications"
         exit 0
         ;;
 esac
 
 MAX_ITERATIONS="${ATLAS_MAX_ITERATIONS:-$DEFAULT_MAX_ITERATIONS}"
 STALE_SECONDS="${ATLAS_STALE_SECONDS:-$DEFAULT_STALE_SECONDS}"
+TIMEOUT_SECONDS="${ATLAS_TIMEOUT:-$DEFAULT_TIMEOUT}"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -90,6 +93,45 @@ done
 mkdir -p "$RUNS_DIR"
 
 log_activity() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$ACTIVITY_LOG"; }
+
+# Check for stale tasks in IN PROGRESS and move back to TODO
+reset_stale_tasks() {
+    [[ "$STALE_SECONDS" -eq 0 ]] && return
+
+    # Check if there's a task in IN PROGRESS
+    local in_progress_task=$(sed -n '/^## IN PROGRESS$/,/^## /{/^### /p;}' "$BACKLOG_FILE" | head -1)
+    [[ -z "$in_progress_task" ]] && return
+
+    # Find most recent run log to determine age
+    local latest_run=$(ls -t "$RUNS_DIR"/*.log 2>/dev/null | head -1)
+    [[ -z "$latest_run" ]] && return
+
+    local last_mod=$(stat -c %Y "$latest_run" 2>/dev/null || stat -f %m "$latest_run" 2>/dev/null)
+    local now=$(date +%s)
+    local age=$((now - last_mod))
+
+    [[ "$age" -le "$STALE_SECONDS" ]] && return
+
+    echo "⚠️  Stale task in IN PROGRESS (${age}s old, threshold: ${STALE_SECONDS}s)"
+    echo "   Resetting to TODO..."
+
+    # Extract full task block from IN PROGRESS
+    local task_block=$(sed -n '/^## IN PROGRESS$/,/^## DONE$/{/^## /d;p;}' "$BACKLOG_FILE")
+    [[ -z "$task_block" ]] && return
+
+    # Create temp file with task moved back to TODO (insert before IN PROGRESS)
+    awk -v task="$task_block" '
+        /^## IN PROGRESS$/ { print task; print ""; print; in_progress=1; next }
+        /^## DONE$/ { in_progress=0 }
+        in_progress && /^### / { next }
+        in_progress && /^- \*\*/ { next }
+        in_progress && /^  [0-9]+\./ { next }
+        { print }
+    ' "$BACKLOG_FILE" > "$BACKLOG_FILE.tmp" && mv "$BACKLOG_FILE.tmp" "$BACKLOG_FILE"
+
+    log_activity "STALE RESET: Moved task back to TODO after ${age}s"
+    echo "✓ Task moved back to TODO"
+}
 
 git_head() { git rev-parse --short HEAD 2>/dev/null || echo ""; }
 
@@ -110,6 +152,8 @@ echo ""
 
 log_activity "RUN START run=$RUN_TAG iterations=$MAX_ITERATIONS"
 
+reset_stale_tasks
+
 for i in $(seq 1 $MAX_ITERATIONS); do
     echo "═══ ITERATION $i/$MAX_ITERATIONS ═══"
 
@@ -127,7 +171,7 @@ ITERATION=$i
 $(cat "$ATLAS_HOME/prompt.md")"
 
     set +e
-    OUTPUT=$(echo "$PROMPT" | claude --dangerously-skip-permissions -p 2>&1 | tee "$LOG_FILE" | tee /dev/stderr) || true
+    OUTPUT=$(echo "$PROMPT" | timeout "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p 2>&1 | tee "$LOG_FILE" | tee /dev/stderr) || true
     set -e
 
     ITER_END=$(date +%s)

--- a/notify-telegram.sh
+++ b/notify-telegram.sh
@@ -45,7 +45,7 @@ PENDING_LINE=$(echo "$SUMMARY" | grep -E "^Pendientes" | head -1)
 # Limpiar valores
 TASK=$(echo "$TASK_LINE" | sed 's/^Tarea: *//')
 STATUS=$(echo "$STATUS_LINE" | sed 's/^Estado: *//')
-PENDING=$(echo "$PENDING_LINE" | sed 's/^Pendientes en backlog: *//')
+PENDING=$(echo "$PENDING_LINE" | sed 's/^Pendientes: *//')
 
 # Determinar emoji de estado
 STATUS_EMOJI="⏳"


### PR DESCRIPTION
## Summary

- Add 20-minute timeout per iteration (`ATLAS_TIMEOUT`) to prevent infinite hangs
- Add stale task recovery (`ATLAS_STALE_SECONDS=7200`) to automatically reset stuck tasks in IN PROGRESS
- Fix telegram parser mismatch for "Pendientes" field

## Test plan

- [ ] Run `atlas help` and verify new env vars are documented
- [ ] Test timeout by setting `ATLAS_TIMEOUT=5` and running a long task
- [ ] Test stale recovery by manually editing backlog with task in IN PROGRESS, wait, and run atlas

🤖 Generated with [Claude Code](https://claude.com/claude-code)