### PR TITLE
docs: clarify all env vars are configurable with ATLAS_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,21 @@ atlas [command] [options]
 
 ### Environment Variables
 
+All settings are configurable via environment variables with the `ATLAS_` prefix:
+
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ATLAS_MAX_ITERATIONS` | Max iterations per run | 10 |
-| `ATLAS_TIMEOUT` | Timeout per iteration (seconds) | 1200 (20 min) |
-| `ATLAS_STALE_SECONDS` | Reset stuck tasks after N seconds | 7200 (2 hours) |
-| `ATLAS_NOTIFY_TELEGRAM` | Enable Telegram notifications | true |
+| `ATLAS_MAX_ITERATIONS` | Max iterations per run | `10` |
+| `ATLAS_TIMEOUT` | Timeout per iteration (seconds) | `1200` (20 min) |
+| `ATLAS_STALE_SECONDS` | Reset stuck tasks after N seconds | `7200` (2 hours) |
+| `ATLAS_NOTIFY_TELEGRAM` | Enable Telegram notifications | `true` |
 | `ATLAS_TELEGRAM_BOT` | Telegram bot token | - |
 | `ATLAS_TELEGRAM_CHAT` | Telegram chat ID | - |
+
+Example:
+```bash
+ATLAS_MAX_ITERATIONS=25 ATLAS_TIMEOUT=900 atlas
+```
 
 ### Timeout
 

--- a/atlas.sh
+++ b/atlas.sh
@@ -70,10 +70,13 @@ case "${1:-}" in
         echo "       atlas update  - Add new files (preserves existing)"
         echo "       atlas 25      - Run 25 iterations"
         echo ""
-        echo "Environment:"
-        echo "  ATLAS_TIMEOUT=1200          Iteration timeout in seconds (default: 1200 = 20min)"
-        echo "  ATLAS_STALE_SECONDS=7200    Reset stuck tasks after N seconds (default: 7200 = 2h)"
+        echo "Environment variables (all configurable):"
+        echo "  ATLAS_MAX_ITERATIONS=10     Max iterations per run"
+        echo "  ATLAS_TIMEOUT=1200          Timeout per iteration in seconds (20 min)"
+        echo "  ATLAS_STALE_SECONDS=7200    Reset stuck tasks after N seconds (2 hours)"
         echo "  ATLAS_NOTIFY_TELEGRAM=false Disable Telegram notifications"
+        echo "  ATLAS_TELEGRAM_BOT=...      Telegram bot token"
+        echo "  ATLAS_TELEGRAM_CHAT=...     Telegram chat ID"
         exit 0
         ;;
 esac


### PR DESCRIPTION
## Summary

- Add missing vars to `atlas help` (ATLAS_MAX_ITERATIONS, ATLAS_TELEGRAM_*)
- Add intro text explaining all vars use ATLAS_ prefix
- Add usage example in README

## Test plan

- [ ] Run `atlas help` and verify all env vars are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)