### PR TITLE
fix: include full content of progress.txt and errors.log

### DIFF
--- a/atlas.sh
+++ b/atlas.sh
@@ -188,14 +188,14 @@ $(cat "$BACKLOG_FILE")
 $(cat "$GUARDRAILS_FILE" 2>/dev/null || echo "# No guardrails yet")
 \`\`\`
 
-## .atlas/progress.txt (last 30 lines)
+## .atlas/progress.txt
 \`\`\`
-$(tail -30 "$PROGRESS_FILE" 2>/dev/null || echo "# No progress yet")
+$(cat "$PROGRESS_FILE" 2>/dev/null || echo "# No progress yet")
 \`\`\`
 
-## .atlas/errors.log (last 20 lines)
+## .atlas/errors.log
 \`\`\`
-$(tail -20 "$ERRORS_LOG" 2>/dev/null || echo "# No errors yet")
+$(cat "$ERRORS_LOG" 2>/dev/null || echo "# No errors yet")
 \`\`\`
 
 ## CLAUDE.md (project rules)


### PR DESCRIPTION
## Summary

Remove arbitrary line limits (30/20 lines) - include full file content.

All learnings and errors are relevant context. If files grow too large, users can clean them manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)