### PR TITLE
refactor: improve prompt clarity and consistency

### DIFF
--- a/atlas.sh
+++ b/atlas.sh
@@ -211,7 +211,7 @@ $(cat "CLAUDE.md" 2>/dev/null || echo "# No CLAUDE.md found - use standard pract
     ITER_DURATION=$((ITER_END - ITER_START))
     HEAD_AFTER=$(git_head)
 
-    SUMMARY=$(echo "$OUTPUT" | sed -n '/=== RESUMEN ===/,/Loop:/p' | head -10)
+    SUMMARY=$(echo "$OUTPUT" | sed -n '/=== SUMMARY ===/,/Loop:/p' | head -10)
     [[ -z "$SUMMARY" ]] && SUMMARY="No summary found"
 
     log_activity "ITERATION $i END duration=${ITER_DURATION}s"

--- a/notify-telegram.sh
+++ b/notify-telegram.sh
@@ -35,47 +35,47 @@ progress_bar() {
 PROGRESS=$(progress_bar "$ITERATION" "$MAX_ITERATIONS")
 TIMESTAMP=$(date "+%H:%M")
 
-# Extraer campos del resumen
-TASK_LINE=$(echo "$SUMMARY" | grep -E "^Tarea:" | head -1)
-STATUS_LINE=$(echo "$SUMMARY" | grep -E "^Estado:" | head -1)
-PENDING_LINE=$(echo "$SUMMARY" | grep -E "^Pendientes" | head -1)
+# Extract fields from summary
+TASK_LINE=$(echo "$SUMMARY" | grep -E "^Task:" | head -1)
+STATUS_LINE=$(echo "$SUMMARY" | grep -E "^Status:" | head -1)
+PENDING_LINE=$(echo "$SUMMARY" | grep -E "^Pending:" | head -1)
 
-# Limpiar valores
-TASK=$(echo "$TASK_LINE" | sed 's/^Tarea: *//')
-STATUS=$(echo "$STATUS_LINE" | sed 's/^Estado: *//')
-PENDING=$(echo "$PENDING_LINE" | sed 's/^Pendientes: *//')
+# Clean values
+TASK=$(echo "$TASK_LINE" | sed 's/^Task: *//')
+STATUS=$(echo "$STATUS_LINE" | sed 's/^Status: *//')
+PENDING=$(echo "$PENDING_LINE" | sed 's/^Pending: *//')
 
-# Determinar emoji de estado
+# Determine status emoji
 STATUS_EMOJI="⏳"
-if [[ "$STATUS" == "HECHO" ]] || [[ "$STATUS" == "DONE" ]]; then
+if [[ "$STATUS" == "DONE" ]]; then
     STATUS_EMOJI="✅"
-elif [[ "$STATUS" == "FALLÓ" ]] || [[ "$STATUS" == "FAILED" ]]; then
+elif [[ "$STATUS" == "FAILED" ]]; then
     STATUS_EMOJI="❌"
-elif [[ "$STATUS" == "NINGUNA" ]] || [[ "$STATUS" == "NONE" ]]; then
+elif [[ "$STATUS" == "SKIPPED" ]]; then
     STATUS_EMOJI="⏸️"
 fi
 
-# Determinar si es la última iteración o si terminó todo
+# Determine footer
 FOOTER=""
 if [[ "$PENDING" == "0" ]]; then
     FOOTER="
-🎉 <b>¡Todas las tareas completadas!</b>"
+🎉 <b>All tasks completed!</b>"
 elif [[ "$ITERATION" == "$MAX_ITERATIONS" ]]; then
     FOOTER="
-⚠️ <i>Máximo de iteraciones alcanzado</i>"
+⚠️ <i>Max iterations reached</i>"
 fi
 
-# Mensaje limpio y elegante
+# Build message
 MESSAGE="<b>Atlas</b> › <code>${PROJECT_NAME}</code>
 
-Iteración <b>${ITERATION}</b>/${MAX_ITERATIONS}  $PROGRESS
+Iteration <b>${ITERATION}</b>/${MAX_ITERATIONS}  $PROGRESS
 
-$STATUS_EMOJI  <b>${TASK:-Sin tarea}</b>
-📋  <b>${PENDING:-?}</b> tareas pendientes en backlog${FOOTER}
+$STATUS_EMOJI  <b>${TASK:-No task}</b>
+📋  <b>${PENDING:-?}</b> pending in backlog${FOOTER}
 
 <i>${TIMESTAMP}</i>"
 
-# Enviar a Telegram
+# Send to Telegram
 curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
     -d "chat_id=${CHAT_ID}" \
     -d "parse_mode=HTML" \

--- a/prompt.md
+++ b/prompt.md
@@ -3,7 +3,14 @@
 You are Atlas, an autonomous coding agent. Iteration $ITERATION of run $RUN_ID.
 Working directory: $PROJECT_DIR
 
-Context files are included below. Do NOT read them again.
+## Setup (FIRST)
+
+Review the context files included below BEFORE starting any task:
+- **CLAUDE.md** - Project rules and quality gates
+- **guardrails.md** - Rules learned from past errors (FOLLOW THEM)
+- **progress.txt** - History and patterns from previous tasks
+- **errors.log** - Recent failures to avoid
+- **backlog.md** - Task list (TODO/IN_PROGRESS/DONE/DELAYED)
 
 ## Algorithm
 
@@ -13,7 +20,7 @@ Context files are included below. Do NOT read them again.
    ELSE → go to step 8
 
 2. IF starting new task:
-   - git checkout -b atlas/[TASK_ID]
+   - Create branch: [type]/[TASK_ID]-[short-description]
    - Move task to IN_PROGRESS in backlog.md
    - git add .atlas/backlog.md && git commit -m "chore: start [TASK_ID]"
 
@@ -23,14 +30,15 @@ Context files are included below. Do NOT read them again.
 
 5. IF quality gates FAIL → go to ERROR HANDLING
 
-6. Complete GitFlow:
-   - gh pr create --title "[type]: [description]" --body "Closes [TASK_ID]"
-   - gh pr merge --squash --delete-branch
-   - git checkout main && git pull
+6. Complete GitFlow (use /commit skill if available, else gh CLI, else git):
+   - Create PR with full description of changes
+   - Merge with squash
+   - Return to main branch
 
 7. Finalize:
    - Move task to DONE with date and PR number
    - Append to progress.txt (see format below)
+   - Add Sign to guardrails.md if you learned something useful
    - git add .atlas/ && git commit -m "chore: complete [TASK_ID]"
 
 8. Print summary (MANDATORY - see format below)
@@ -60,7 +68,7 @@ Notes: [any gotchas for future iterations]
 [DATE] [TASK_ID]: [brief error description]
 ```
 
-**guardrails.md** (add Sign if learned something):
+**guardrails.md** (add Sign when you learn something):
 ```
 ### Sign: [Name]
 - **Trigger**: [when to apply]
@@ -73,11 +81,11 @@ Notes: [any gotchas for future iterations]
 Print this EXACT format at the END of every iteration:
 
 ```
-=== RESUMEN ===
-Tarea: [TASK_ID] - [description]
-Estado: [HECHO | FALLÓ | NINGUNA]
-Pendientes: [NUMBER]
-Loop: [CONTINUAR | COMPLETADO]
+=== SUMMARY ===
+Task: [TASK_ID] - [description]
+Status: [DONE | FAILED | SKIPPED]
+Pending: [NUMBER]
+Loop: [CONTINUE | COMPLETE]
 ```
 
 If TODO and IN_PROGRESS are both empty:
@@ -88,7 +96,8 @@ If TODO and IN_PROGRESS are both empty:
 ## Rules
 
 - ONE task per iteration
-- ALWAYS commit backlog.md changes immediately
+- READ context files BEFORE starting
+- WRITE to progress.txt and guardrails.md AFTER completing
+- ALWAYS commit state changes immediately
 - ALWAYS end on main branch
 - ALWAYS print summary at the end
-- Prefer `gh` CLI, fallback to git if unavailable


### PR DESCRIPTION
## Summary

Major prompt improvements based on feedback:

### Prompt changes
- **Setup section**: Review context files BEFORE starting task
- **Branch naming**: `[type]/[TASK_ID]-[short-description]` instead of `atlas/`
- **GitFlow**: Use `/commit` skill if available, else `gh` CLI, else git
- **PR body**: Full description of changes (not arbitrary text)
- **Language**: All in English (DONE/FAILED/SKIPPED)
- **Clear flow**: READ context before, WRITE progress after

### notify-telegram.sh
- Parse English fields (Task/Status/Pending)
- English messages

### atlas.sh
- Parse `=== SUMMARY ===` instead of `=== RESUMEN ===`

🤖 Generated with [Claude Code](https://claude.com/claude-code)