### PR TITLE
feat: add CHANGELOG.md and GitHub Action for auto releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from CHANGELOG.md
+        id: version
+        run: |
+          # Get the first version that's not [Unreleased]
+          VERSION=$(grep -m 1 '^\#\# \[[0-9]' CHANGELOG.md | sed 's/.*\[\([0-9.]*\)\].*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "Found version: $VERSION"
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.version.outputs.version }} does not exist, will create release"
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        if: steps.check_tag.outputs.exists == 'false'
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Extract content between this version header and the next version header
+          NOTES=$(awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+
+          # Write to file for multiline support
+          echo "$NOTES" > release_notes.md
+          echo "Release notes:"
+          cat release_notes.md
+
+      - name: Create Release
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.3.0] - 2026-01-16
+
+### Added
+- Iteration timeout (20 min default, configurable via `ATLAS_TIMEOUT`)
+- Stale task recovery (auto-reset stuck IN_PROGRESS tasks after 2 hours)
+- Pre-load all context files into prompt (no tool calls needed)
+- `atlas update` now downloads latest version from GitHub
+- Clear file formats for progress.txt, errors.log, guardrails.md
+- Setup section in prompt: read context files BEFORE starting
+- Error handling flow: move failed tasks to DELAYED
+
+### Changed
+- Prompt rewritten for clarity and consistency
+- All output in English (summary, status, telegram notifications)
+- Branch naming: `[type]/[TASK_ID]-[description]` instead of `atlas/`
+- GitFlow: prefer /commit skill, fallback to gh CLI, then git
+- PR body: full description instead of arbitrary text
+- progress.txt logging is now mandatory (was optional)
+- README simplified and updated
+
+### Fixed
+- Telegram parser mismatch for "Pendientes" field
+- Spanish comments translated to English
+
+## [1.2.0] - 2026-01-15
+
+### Added
+- Silent retry for transient CLI errors
+- GitHub Action for automatic releases
+- Release workflow instructions in CLAUDE.md
+
+### Changed
+- Simplified architecture to backlog.md only (removed prd.json)
+
+## [1.1.0] - 2026-01-14
+
+### Added
+- Telegram notifications with progress bar
+- Guardrails system (Signs methodology)
+- Progress tracking across iterations
+
+## [1.0.0] - 2026-01-14
+
+### Added
+- Initial release
+- Ralph Wiggum loop implementation
+- Basic backlog processing
+- GitFlow integration (branch, PR, merge)


### PR DESCRIPTION
## Summary

- Add CHANGELOG.md with version history (1.0.0 → 1.3.0)
- Add GitHub Action workflow for automatic releases
- Reads version directly from CHANGELOG.md (not atlas.sh)
- Creates GitHub release with changelog notes on push to main

## How it works

1. On push to main, workflow extracts latest version from CHANGELOG.md
2. Checks if tag already exists
3. If not, extracts release notes and creates GitHub release

## Test plan

- [ ] Merge this PR
- [ ] Verify GitHub Action runs and creates v1.3.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)