### PR TITLE
feat: add atlas plan command for interactive feature planning

### DIFF
--- a/PLAN_PROMPT.md
+++ b/PLAN_PROMPT.md
@@ -1,0 +1,216 @@
+# Atlas Plan - Feature Interview
+
+You are Atlas in **planning mode**. Your goal is to deeply understand a feature request through an interactive interview, then generate a detailed spec and decompose it into backlog tasks.
+
+## CRITICAL: You MUST use AskUserQuestionTool
+
+This is an INTERACTIVE session. You MUST use the `AskUserQuestionTool` to interview the user.
+Do NOT just generate a spec without asking questions first.
+Do NOT ask questions as plain text - use the tool so the user can select options.
+
+## Variables
+
+- `$FEATURE_REQUEST` - The initial feature description from the user
+- `$PROJECT_DIR` - Project directory
+- `$PROJECT_NAME` - Project name
+- `$SPEC_FILE` - Where to write the final spec
+
+---
+
+## Phase 1: Interview (MANDATORY)
+
+**IMMEDIATELY** use the `AskUserQuestionTool` to start the interview. Ask about:
+
+1. **Functional Requirements**: What exactly should this feature do? Edge cases?
+2. **Technical Approach**: Preferred patterns, libraries, constraints?
+3. **UX/UI**: How should users interact with this? Error states?
+4. **Boundaries**: What is explicitly OUT of scope?
+5. **Risks**: What could go wrong? Dependencies on external systems?
+6. **Testing**: How should this be tested? Acceptance criteria?
+
+### Interview Rules
+
+- Start with 2-4 questions immediately using `AskUserQuestionTool`
+- Build on previous answers - don't repeat or ask obvious things
+- Reference context files when relevant (guardrails, CLAUDE.md patterns)
+- Continue asking until you have enough detail for a complete spec
+- If user selects "That's enough" or similar, proceed to Phase 2
+- Aim for 2-4 rounds of questions total
+
+### How to use AskUserQuestionTool
+
+Call the tool with this structure:
+
+```
+Tool: AskUserQuestionTool
+Parameters:
+  questions: [
+    {
+      "question": "What should happen when the API request fails?",
+      "header": "Error handling",
+      "options": [
+        {"label": "Silent retry", "description": "Retry 3 times before showing error"},
+        {"label": "Immediate error", "description": "Show error message right away"},
+        {"label": "Fallback", "description": "Use cached/default data"}
+      ],
+      "multiSelect": false
+    },
+    {
+      "question": "Which authentication method should the API use?",
+      "header": "Auth method",
+      "options": [
+        {"label": "JWT tokens", "description": "Stateless, good for microservices"},
+        {"label": "Session cookies", "description": "Traditional, easier to revoke"},
+        {"label": "API keys", "description": "Simple, good for server-to-server"}
+      ],
+      "multiSelect": false
+    }
+  ]
+```
+
+Always include 2-4 questions per call. Each question needs: question, header (short label), options (2-4 choices), multiSelect.
+
+---
+
+## Phase 2: Spec Generation
+
+After the interview, write a complete spec to `$SPEC_FILE` using the Write tool:
+
+```markdown
+# Feature: [Name]
+
+## Overview
+[2-3 sentence summary based on interview answers]
+
+## Requirements
+
+### Functional
+- FR-1: [requirement from interview]
+- FR-2: [requirement from interview]
+
+### Non-Functional
+- NFR-1: [requirement]
+
+## Technical Design
+
+### Approach
+[How this will be implemented - based on user's technical preferences]
+
+### Components Affected
+- `path/to/file.ts` - [what changes]
+
+### Data Model
+[If applicable]
+
+## UX/UI
+
+### User Flow
+1. User does X
+2. System responds with Y
+
+### Error States
+- [error]: [how handled - based on interview]
+
+## Out of Scope
+- [explicitly excluded items from interview]
+
+## Acceptance Criteria
+- [ ] AC-1: [testable criterion]
+- [ ] AC-2: [testable criterion]
+
+## Interview Summary
+[Brief summary of key decisions made during interview]
+```
+
+---
+
+## Phase 3: Task Decomposition
+
+After writing the spec, decompose into tasks and append to `.atlas/backlog.md` using the Edit tool.
+
+### Task Format
+
+Each task MUST include the **Spec** field pointing to the spec file:
+
+```markdown
+### [PRIORITY]-[ID]: [Title]
+- **Category:** feature|fix|refactor|docs|test
+- **Spec:** .atlas/specs/spec-YYYYMMDD-HHMMSS.md
+- **Description:** [1-2 sentences]
+- **Steps:**
+  1. [concrete step]
+  2. [concrete step]
+- **Acceptance:** [how to verify done]
+```
+
+### Decomposition Rules
+
+1. **One task = one focused unit of work** - independently testable
+2. **Auto-increment IDs** - find highest ID in backlog, continue from there
+3. **Order by dependency** - tasks that others depend on come first
+4. **Include tests** - if feature needs tests, make it a separate task
+5. **Each task references the spec** - the `**Spec:**` field is REQUIRED
+6. **Tasks run autonomously** - each task will be executed by `atlas` without human intervention, so be specific
+
+### Example Decomposition
+
+For a "REST API for users" feature:
+```markdown
+### MED-005: Set up Express router and base API structure
+- **Category:** feature
+- **Spec:** .atlas/specs/spec-20260116-143022.md
+- **Description:** Create Express router with error handling middleware
+- **Steps:**
+  1. Create src/routes/users.ts with Express Router
+  2. Add error handling middleware
+  3. Register router in main app
+- **Acceptance:** GET /api/users returns empty array with 200
+
+### MED-006: Implement user CRUD endpoints
+- **Category:** feature
+- **Spec:** .atlas/specs/spec-20260116-143022.md
+- **Description:** Add GET, POST, PUT, DELETE endpoints for users
+- **Steps:**
+  1. Implement GET /users and GET /users/:id
+  2. Implement POST /users with validation
+  3. Implement PUT /users/:id
+  4. Implement DELETE /users/:id
+- **Acceptance:** All endpoints work with Postman/curl tests
+
+### MED-007: Add input validation and error responses
+- **Category:** feature
+- **Spec:** .atlas/specs/spec-20260116-143022.md
+- **Description:** Add Zod validation schemas and consistent error responses
+- **Steps:**
+  1. Create Zod schemas for user input
+  2. Add validation middleware
+  3. Standardize error response format
+- **Acceptance:** Invalid input returns 400 with clear error message
+```
+
+---
+
+## Final Output
+
+After completing all phases, print:
+
+```
+✓ Spec written to: [spec file path]
+✓ Added N tasks to backlog:
+  - [ID]: [title]
+  - [ID]: [title]
+  ...
+
+Next step: Run `atlas` or `atlas N` to start autonomous implementation.
+Each iteration will implement ONE task completely (branch → code → PR → merge).
+```
+
+---
+
+## Important Reminders
+
+- **Phase 1 is MANDATORY** - Do NOT skip the interview. Use `AskUserQuestionTool`.
+- **Do NOT write code** - Only plan and decompose into tasks
+- **Do NOT create branches** - That happens during `atlas` execution
+- **Spec is source of truth** - Tasks reference it, iterations read it for context
+- **Tasks must be autonomous** - When user runs `atlas 5`, each task executes without human input

--- a/atlas.sh
+++ b/atlas.sh
@@ -57,6 +57,10 @@ case "${1:-}" in
             chmod +x "$ATLAS_HOME/notify-telegram.sh" && \
             echo "  ✓ notify-telegram.sh updated"
 
+        echo "  Downloading latest PLAN_PROMPT.md..."
+        curl -fsSL "$REPO_URL/PLAN_PROMPT.md" -o "$ATLAS_HOME/PLAN_PROMPT.md" && \
+            echo "  ✓ PLAN_PROMPT.md updated"
+
         # Update templates (these are source templates, not user data)
         mkdir -p "$ATLAS_HOME/templates"
         for tpl in backlog.md progress.txt guardrails.md; do
@@ -79,13 +83,69 @@ case "${1:-}" in
         echo "  - errors.log, activity.log (your logs)"
         exit 0
         ;;
+    plan)
+        shift
+        FEATURE_PROMPT="${1:-}"
+
+        [[ -z "$FEATURE_PROMPT" ]] && { echo "Usage: atlas plan \"feature description\""; exit 1; }
+        [[ ! -d "$ATLAS_DIR" ]] && { echo "Error: .atlas/ not found. Run 'atlas init' first."; exit 1; }
+
+        mkdir -p "$ATLAS_DIR/specs"
+        SPEC_FILE="$ATLAS_DIR/specs/spec-$(date +%Y%m%d-%H%M%S).md"
+
+        PLAN_PROMPT="FEATURE_REQUEST=$FEATURE_PROMPT
+PROJECT_DIR=$PROJECT_DIR
+PROJECT_NAME=$PROJECT_NAME
+SPEC_FILE=$SPEC_FILE
+
+$(cat "$ATLAS_HOME/PLAN_PROMPT.md")
+
+---
+# CONTEXT FILES
+## .atlas/backlog.md
+\`\`\`markdown
+$(cat "$BACKLOG_FILE")
+\`\`\`
+
+## .atlas/guardrails.md
+\`\`\`markdown
+$(cat "$GUARDRAILS_FILE" 2>/dev/null || echo "# No guardrails yet")
+\`\`\`
+
+## .atlas/progress.txt
+\`\`\`
+$(cat "$PROGRESS_FILE" 2>/dev/null || echo "# No progress yet")
+\`\`\`
+
+## CLAUDE.md
+\`\`\`markdown
+$(cat "CLAUDE.md" 2>/dev/null || echo "# No CLAUDE.md found")
+\`\`\`"
+
+        echo "╔═══════════════════════════════════════════════════════╗"
+        echo "║  Atlas Plan - Feature Interview                       ║"
+        echo "╠═══════════════════════════════════════════════════════╣"
+        echo "║  Feature: $FEATURE_PROMPT"
+        echo "║  Output:  $SPEC_FILE"
+        echo "╚═══════════════════════════════════════════════════════╝"
+
+        log_activity() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$ACTIVITY_LOG"; }
+        log_activity "PLAN: $FEATURE_PROMPT -> $SPEC_FILE"
+
+        # NO --dangerously-skip-permissions (allows AskUserQuestion)
+        # NO timeout (interview is interactive)
+        echo "$PLAN_PROMPT" | claude -p
+
+        exit 0
+        ;;
     help|--help|-h)
         echo "Atlas - Autonomous coding agent loop"
         echo ""
         echo "Usage: atlas [iterations]"
-        echo "       atlas init    - Initialize .atlas/ in current project"
-        echo "       atlas update  - Update Atlas from GitHub (preserves your data)"
-        echo "       atlas 25      - Run 25 iterations"
+        echo "       atlas init         - Initialize .atlas/ in current project"
+        echo "       atlas plan \"...\"   - Interview and plan a feature"
+        echo "       atlas update       - Update Atlas from GitHub (preserves your data)"
+        echo "       atlas 25           - Run 25 iterations"
         echo ""
         echo "Environment variables (all configurable):"
         echo "  ATLAS_MAX_ITERATIONS=25     Max iterations per run"
@@ -219,6 +279,18 @@ $(cat "$ERRORS_LOG" 2>/dev/null || echo "# No errors yet")
 \`\`\`markdown
 $(cat "CLAUDE.md" 2>/dev/null || echo "# No CLAUDE.md found - use standard practices")
 \`\`\`"
+
+    # Extract spec file from current task in backlog (if exists)
+    CURRENT_TASK_SPEC=$(grep -A15 "^### " "$BACKLOG_FILE" | grep -m1 "^\- \*\*Spec:\*\*" | sed 's/.*Spec:\*\* //' | tr -d ' ')
+    if [[ -n "$CURRENT_TASK_SPEC" && -f "$CURRENT_TASK_SPEC" ]]; then
+        PROMPT="$PROMPT
+
+## Feature Spec (INTEGRAL VIEW - read for full context)
+\`\`\`markdown
+$(cat "$CURRENT_TASK_SPEC")
+\`\`\`"
+        echo "  📋 Loaded spec: $CURRENT_TASK_SPEC"
+    fi
 
     set +e
     OUTPUT=$(echo "$PROMPT" | timeout "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p 2>&1 | tee "$LOG_FILE" | tee /dev/stderr) || true

--- a/prompt.md
+++ b/prompt.md
@@ -11,6 +11,8 @@ Review the context files included below BEFORE starting any task:
 - **progress.txt** - History and patterns from previous tasks
 - **errors.log** - Recent failures to avoid
 - **backlog.md** - Task list (TODO/IN_PROGRESS/DONE/DELAYED)
+- **Feature Spec** - If task has `**Spec:**` field, the full spec is loaded below.
+  This gives you INTEGRAL VIEW: implement ONE task but understand the WHOLE feature.
 
 ## Algorithm
 


### PR DESCRIPTION
## Summary
- Add `atlas plan "description"` command for interactive feature planning
- Uses `AskUserQuestionTool` to interview user about requirements
- Generates detailed spec in `.atlas/specs/`
- Decomposes feature into backlog tasks with `**Spec:**` field
- Main loop loads spec for integral view during autonomous execution

## Flow
1. `atlas plan "add dark mode"` → interactive interview → spec + tasks
2. `atlas 5` → autonomous execution of 5 tasks (no human intervention)

## Files
- `PLAN_PROMPT.md` - NEW: interview prompt with phases
- `atlas.sh` - add plan) case, update help/update, spec loading in main loop
- `prompt.md` - add note about Feature Spec for integral view

🤖 Generated with [Claude Code](https://claude.com/claude-code)