### PR TITLE
fix: ATLAS_HOME path

### DIFF
--- a/atlas.sh
+++ b/atlas.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-ATLAS_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ATLAS_HOME="${HOME}/.atlas"
 PROJECT_DIR="$(pwd)"
 PROJECT_NAME="$(basename "$PROJECT_DIR")"
 NOTIFY_TELEGRAM="${ATLAS_NOTIFY_TELEGRAM:-true}"


### PR DESCRIPTION
Binary can be anywhere, but support files are in ~/.atlas/