### PR TITLE
fix: telegram notification emoji pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-01-16
+
+### Fixed
+- Telegram notification emoji now uses pattern matching for statuses with extra info (e.g., "SKIPPED (already fixed)" now correctly shows ⏭️ instead of ⏳)
+
 ## [1.5.0] - 2026-01-16
 
 ### Fixed

--- a/notify-telegram.sh
+++ b/notify-telegram.sh
@@ -45,14 +45,14 @@ TASK=$(echo "$TASK_LINE" | sed 's/^Task: *//')
 STATUS=$(echo "$STATUS_LINE" | sed 's/^Status: *//')
 PENDING=$(echo "$PENDING_LINE" | sed 's/^Pending: *//')
 
-# Determine status emoji
+# Determine status emoji (pattern matching for statuses with extra info like "SKIPPED (reason)")
 STATUS_EMOJI="⏳"
-if [[ "$STATUS" == "DONE" ]]; then
+if [[ "$STATUS" == DONE* ]]; then
     STATUS_EMOJI="✅"
-elif [[ "$STATUS" == "FAILED" ]]; then
+elif [[ "$STATUS" == FAILED* ]]; then
     STATUS_EMOJI="❌"
-elif [[ "$STATUS" == "SKIPPED" ]]; then
-    STATUS_EMOJI="⏸️"
+elif [[ "$STATUS" == SKIPPED* ]]; then
+    STATUS_EMOJI="⏭️"
 fi
 
 # Determine footer


### PR DESCRIPTION
## Problem

Status values like `SKIPPED (already fixed)` were not matching exact string comparisons in `notify-telegram.sh`, causing the default ⏳ emoji to show instead of the correct status emoji.

## Solution

Changed from exact match (`== "SKIPPED"`) to pattern match (`== SKIPPED*`) so statuses with additional context are handled correctly.

## Changes

- `notify-telegram.sh`: Use pattern matching for DONE/FAILED/SKIPPED statuses
- Changed SKIPPED emoji from ⏸️ to ⏭️ (skip-forward is more semantically correct)
- `CHANGELOG.md`: Added v1.5.1 entry