### PR TITLE
feat: reference context files instead of injecting content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-01-16
+
+### Changed
+- Prompt architecture: reference files instead of injecting content
+- Context files listed in CONTEXT_FILES_TO_READ variable for selective reading
+- Smaller initial prompt size, more scalable as files grow
+- Agent reads files on-demand using Read tool (parallel reads for efficiency)
+
+### Technical
+- atlas.sh builds dynamic file list based on which files exist
+- prompt.md updated with mandatory file reading instructions
+- Variables exposed: BACKLOG_FILE, GUARDRAILS_FILE, PROGRESS_FILE, ERRORS_LOG, SPEC_FILE
+
 ## [1.5.1] - 2026-01-16
 
 ### Fixed

--- a/atlas.sh
+++ b/atlas.sh
@@ -202,54 +202,43 @@ for i in $(seq 1 $MAX_ITERATIONS); do
 
     log_activity "ITERATION $i START"
 
-    # Build prompt with all context files included
+    # Build list of context files that exist
+    CONTEXT_FILES=""
+    [[ -f "$BACKLOG_FILE" ]] && CONTEXT_FILES="$CONTEXT_FILES
+- $BACKLOG_FILE (REQUIRED - task queue)"
+    [[ -f "$GUARDRAILS_FILE" ]] && CONTEXT_FILES="$CONTEXT_FILES
+- $GUARDRAILS_FILE (rules from past errors)"
+    [[ -f "$PROGRESS_FILE" ]] && CONTEXT_FILES="$CONTEXT_FILES
+- $PROGRESS_FILE (history of completed tasks)"
+    [[ -f "$ERRORS_LOG" ]] && CONTEXT_FILES="$CONTEXT_FILES
+- $ERRORS_LOG (recent failures)"
+    [[ -f "CLAUDE.md" ]] && CONTEXT_FILES="$CONTEXT_FILES
+- CLAUDE.md (project rules and quality gates)"
+
+    # Extract spec file from current task in backlog (if exists)
+    SPEC_FILE=""
+    CURRENT_TASK_SPEC=$(grep -A15 "^### " "$BACKLOG_FILE" | grep -m1 "^\- \*\*Spec:\*\*" | sed 's/.*Spec:\*\* //' | tr -d ' ')
+    if [[ -n "$CURRENT_TASK_SPEC" && -f "$CURRENT_TASK_SPEC" ]]; then
+        SPEC_FILE="$CURRENT_TASK_SPEC"
+        CONTEXT_FILES="$CONTEXT_FILES
+- $CURRENT_TASK_SPEC (INTEGRAL VIEW - full feature spec)"
+        echo "  📋 Spec found: $CURRENT_TASK_SPEC"
+    fi
+
+    # Build prompt with file references (not content)
     PROMPT="PROJECT_DIR=$PROJECT_DIR
 PROJECT_NAME=$PROJECT_NAME
 RUN_ID=$RUN_TAG
 ITERATION=$i
+BACKLOG_FILE=$BACKLOG_FILE
+GUARDRAILS_FILE=$GUARDRAILS_FILE
+PROGRESS_FILE=$PROGRESS_FILE
+ERRORS_LOG=$ERRORS_LOG
+SPEC_FILE=$SPEC_FILE
 
-$(cat "$ATLAS_HOME/prompt.md")
+CONTEXT_FILES_TO_READ:$CONTEXT_FILES
 
----
-
-# CONTEXT FILES (already loaded - do NOT read again)
-
-## .atlas/backlog.md
-\`\`\`markdown
-$(cat "$BACKLOG_FILE")
-\`\`\`
-
-## .atlas/guardrails.md
-\`\`\`markdown
-$(cat "$GUARDRAILS_FILE" 2>/dev/null || echo "# No guardrails yet")
-\`\`\`
-
-## .atlas/progress.txt
-\`\`\`
-$(cat "$PROGRESS_FILE" 2>/dev/null || echo "# No progress yet")
-\`\`\`
-
-## .atlas/errors.log
-\`\`\`
-$(cat "$ERRORS_LOG" 2>/dev/null || echo "# No errors yet")
-\`\`\`
-
-## CLAUDE.md (project rules)
-\`\`\`markdown
-$(cat "CLAUDE.md" 2>/dev/null || echo "# No CLAUDE.md found - use standard practices")
-\`\`\`"
-
-    # Extract spec file from current task in backlog (if exists)
-    CURRENT_TASK_SPEC=$(grep -A15 "^### " "$BACKLOG_FILE" | grep -m1 "^\- \*\*Spec:\*\*" | sed 's/.*Spec:\*\* //' | tr -d ' ')
-    if [[ -n "$CURRENT_TASK_SPEC" && -f "$CURRENT_TASK_SPEC" ]]; then
-        PROMPT="$PROMPT
-
-## Feature Spec (INTEGRAL VIEW - read for full context)
-\`\`\`markdown
-$(cat "$CURRENT_TASK_SPEC")
-\`\`\`"
-        echo "  📋 Loaded spec: $CURRENT_TASK_SPEC"
-    fi
+$(cat "$ATLAS_HOME/prompt.md")"
 
     set +e
     OUTPUT=$(echo "$PROMPT" | timeout "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p 2>&1 | tee "$LOG_FILE" | tee /dev/stderr) || true

--- a/prompt.md
+++ b/prompt.md
@@ -3,16 +3,19 @@
 You are Atlas, an autonomous coding agent. Iteration $ITERATION of run $RUN_ID.
 Working directory: $PROJECT_DIR
 
-## Setup (FIRST)
+## Setup (FIRST - MANDATORY)
 
-Review the context files included below BEFORE starting any task:
-- **CLAUDE.md** - Project rules and quality gates
-- **guardrails.md** - Rules learned from past errors (FOLLOW THEM)
+**Read ALL context files listed in CONTEXT_FILES_TO_READ above BEFORE doing anything else.**
+
+Use the Read tool to load each file. These files contain critical context:
+- **backlog.md** - Task queue (TODO/IN_PROGRESS/DONE/DELAYED)
+- **guardrails.md** - Rules learned from past errors (MUST FOLLOW)
 - **progress.txt** - History and patterns from previous tasks
-- **errors.log** - Recent failures to avoid
-- **backlog.md** - Task list (TODO/IN_PROGRESS/DONE/DELAYED)
-- **Feature Spec** - If task has `**Spec:**` field, the full spec is loaded below.
-  This gives you INTEGRAL VIEW: implement ONE task but understand the WHOLE feature.
+- **errors.log** - Recent failures to avoid repeating
+- **CLAUDE.md** - Project rules and quality gates
+- **Feature Spec** - If SPEC_FILE is set, read it for INTEGRAL VIEW of the feature
+
+Do NOT skip this step. Read files in parallel for efficiency.
 
 ## Algorithm
 


### PR DESCRIPTION
## Summary
- Prompt architecture change: reference files instead of injecting content
- Agent reads context files on-demand using Read tool (parallel reads recommended)
- Smaller initial prompt, more scalable as state files grow

## Changes
- `atlas.sh`: Build dynamic file list, expose path variables (BACKLOG_FILE, GUARDRAILS_FILE, etc.)
- `prompt.md`: Updated setup instructions for mandatory file reading
- `CHANGELOG.md`: Added v1.6.0 entry

## Test plan
- [ ] Run `atlas 1` on a test project with all context files
- [ ] Run `atlas 1` on a project missing some optional files
- [ ] Verify agent correctly reads and follows context

🤖 Generated with [Claude Code](https://claude.com/claude-code)