### PR TITLE
fix: show 'already up to date' when atlas update finds no new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `atlas update` shows "already up to date" when on latest version
+
 ## [1.6.0] - 2026-01-16
 
 ### Changed

--- a/atlas.sh
+++ b/atlas.sh
@@ -60,7 +60,11 @@ case "${1:-}" in
         # Get new version (skip Unreleased, find first X.Y.Z)
         NEW_VERSION=$(grep -m1 "^## \[[0-9]" "$ATLAS_HOME/CHANGELOG.md" | sed 's/## \[\(.*\)\].*/\1/')
 
-        echo "✓ Atlas updated: v$OLD_VERSION → v$NEW_VERSION"
+        if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+            echo "✓ Atlas v$NEW_VERSION (already up to date)"
+        else
+            echo "✓ Atlas updated: v$OLD_VERSION → v$NEW_VERSION"
+        fi
         exit 0
         ;;
     plan)


### PR DESCRIPTION
## Summary
- Avoid confusing output like `v1.6.0 → v1.6.0`
- Now shows `✓ Atlas v1.6.0 (already up to date)` when already on latest

## Test plan
- [ ] Run `atlas update` when already on latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)