### PR TITLE
release: v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-01-16
+
 ### Fixed
 - `atlas update` shows "already up to date" when on latest version
 


### PR DESCRIPTION
## Summary
- Release v1.6.1

### Fixed
- `atlas update` shows "already up to date" when on latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)