### PR TITLE
feat: minimal initial prompt with file references only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-01-16
+
+### Changed
+- Minimal initial prompt: only variables and file references (~10 lines vs ~100)
+- prompt.md now referenced via PROMPT_FILE instead of injected
+- Agent reads instructions from file like any other context file
+- More scalable: prompt size no longer grows with instruction changes
+
 ## [1.6.1] - 2026-01-16
 
 ### Fixed

--- a/atlas.sh
+++ b/atlas.sh
@@ -229,20 +229,19 @@ for i in $(seq 1 $MAX_ITERATIONS); do
         echo "  📋 Spec found: $CURRENT_TASK_SPEC"
     fi
 
-    # Build prompt with file references (not content)
+    # Build minimal prompt with file references only
     PROMPT="PROJECT_DIR=$PROJECT_DIR
 PROJECT_NAME=$PROJECT_NAME
 RUN_ID=$RUN_TAG
 ITERATION=$i
-BACKLOG_FILE=$BACKLOG_FILE
-GUARDRAILS_FILE=$GUARDRAILS_FILE
-PROGRESS_FILE=$PROGRESS_FILE
-ERRORS_LOG=$ERRORS_LOG
-SPEC_FILE=$SPEC_FILE
 
-CONTEXT_FILES_TO_READ:$CONTEXT_FILES
+PROMPT_FILE=$ATLAS_HOME/prompt.md
 
-$(cat "$ATLAS_HOME/prompt.md")"
+CONTEXT_FILES:$CONTEXT_FILES
+
+---
+
+You are Atlas. Read PROMPT_FILE for your instructions, then read all CONTEXT_FILES listed above."
 
     set +e
     OUTPUT=$(echo "$PROMPT" | timeout "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p 2>&1 | tee "$LOG_FILE" | tee /dev/stderr) || true

--- a/prompt.md
+++ b/prompt.md
@@ -5,9 +5,9 @@ Working directory: $PROJECT_DIR
 
 ## Setup (FIRST - MANDATORY)
 
-**Read ALL context files listed in CONTEXT_FILES_TO_READ above BEFORE doing anything else.**
+**Read ALL files listed in CONTEXT_FILES (from the initial prompt) BEFORE doing anything else.**
 
-Use the Read tool to load each file. These files contain critical context:
+Use the Read tool to load each file in parallel. These files contain critical context:
 - **backlog.md** - Task queue (TODO/IN_PROGRESS/DONE/DELAYED)
 - **guardrails.md** - Rules learned from past errors (MUST FOLLOW)
 - **progress.txt** - History and patterns from previous tasks


### PR DESCRIPTION
## Summary
- Initial prompt reduced from ~100 lines to ~16 lines
- `prompt.md` now referenced via `PROMPT_FILE` variable instead of injected
- Agent reads instructions like any other context file

## Before vs After

**Before (v1.6.x):**
```
PROJECT_DIR=...
CONTEXT_FILES_TO_READ:...

# Atlas Agent
You are Atlas...
[~90 more lines of instructions]
```

**After (v1.7.0):**
```
PROJECT_DIR=...
PROMPT_FILE=~/.atlas/prompt.md
CONTEXT_FILES:...

---
You are Atlas. Read PROMPT_FILE for your instructions, then read all CONTEXT_FILES listed above.
```

## Test plan
- [ ] Run `atlas 1` and verify agent reads prompt.md correctly
- [ ] Verify agent reads all context files

🤖 Generated with [Claude Code](https://claude.com/claude-code)