### PR TITLE
fix: use explicit envsubst for variable substitution in prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-01-18
+
+### Changed
+- Variables in prompt.md and plan_prompt.md now use explicit `envsubst` substitution
+- Previously Claude had to mentally connect `ITERATION=2` with `$ITERATION` in text
+- Now Claude receives fully processed text: "Iteration 2 of run..." directly
+- More robust and less dependent on Claude's inference
+
 ## [1.9.0] - 2026-01-18
 
 ### Fixed

--- a/atlas.sh
+++ b/atlas.sh
@@ -78,13 +78,12 @@ case "${1:-}" in
         mkdir -p "$ATLAS_DIR/specs"
         SPEC_FILE="$ATLAS_DIR/specs/spec-$(date +%Y%m%d-%H%M%S).md"
 
-        PLAN_PROMPT="FEATURE_REQUEST=$FEATURE_PROMPT
-PROJECT_DIR=$PROJECT_DIR
-PROJECT_NAME=$PROJECT_NAME
-SPEC_FILE=$SPEC_FILE
-BACKLOG_FILE=$BACKLOG_FILE
+        # Export variables for envsubst
+        export FEATURE_REQUEST="$FEATURE_PROMPT"
+        export PROJECT_DIR PROJECT_NAME SPEC_FILE BACKLOG_FILE
 
-$(cat "$ATLAS_HOME/plan_prompt.md")"
+        # Process plan_prompt.md with variable substitution
+        PLAN_PROMPT=$(envsubst '$FEATURE_REQUEST $PROJECT_DIR $PROJECT_NAME $SPEC_FILE $BACKLOG_FILE' < "$ATLAS_HOME/plan_prompt.md")
 
         echo "╔═══════════════════════════════════════════════════════╗"
         echo "║  Atlas Plan - Feature Interview                       ║"
@@ -246,19 +245,20 @@ for i in $(seq 1 $MAX_ITERATIONS); do
         echo "  📋 Spec found: $CURRENT_TASK_SPEC"
     fi
 
-    # Build minimal prompt with file references only
-    PROMPT="PROJECT_DIR=$PROJECT_DIR
-PROJECT_NAME=$PROJECT_NAME
-RUN_ID=$RUN_TAG
-ITERATION=$i
+    # Export variables for envsubst
+    export PROJECT_DIR PROJECT_NAME
+    export RUN_ID="$RUN_TAG"
+    export ITERATION="$i"
 
-PROMPT_FILE=$ATLAS_HOME/prompt.md
+    # Process prompt.md with variable substitution
+    PROMPT_CONTENT=$(envsubst '$PROJECT_DIR $PROJECT_NAME $RUN_ID $ITERATION' < "$ATLAS_HOME/prompt.md")
 
-CONTEXT_FILES:$CONTEXT_FILES
+    # Build prompt with processed instructions inline
+    PROMPT="CONTEXT_FILES:$CONTEXT_FILES
 
 ---
 
-You are Atlas. Read PROMPT_FILE for your instructions, then read all CONTEXT_FILES listed above."
+$PROMPT_CONTENT"
 
     set +e
     # Write prompt to temp file to avoid pipe issues with signals


### PR DESCRIPTION
## Summary
Use `envsubst` to explicitly replace variables in prompt.md and plan_prompt.md before sending to Claude.

## Problem
Previously, atlas.sh sent:
```
ITERATION=2
...
Read PROMPT_FILE for your instructions
```

And prompt.md contained:
```
Iteration $ITERATION of run $RUN_ID.
```

Claude had to mentally connect that `ITERATION=2` meant `$ITERATION` should be `2`.

## Solution
Now atlas.sh processes prompt.md with `envsubst`:
```bash
export ITERATION="$i"
PROMPT_CONTENT=$(envsubst '$ITERATION $RUN_ID ...' < prompt.md)
```

Claude receives the final text directly:
```
Iteration 2 of run 20260118-130203.
```

## Changes
| File | Change |
|------|--------|
| atlas.sh | Use envsubst for prompt.md and plan_prompt.md |
| CHANGELOG.md | Document v1.9.1 |

## Test
```bash
$ export ITERATION=5 RUN_ID=test PROJECT_DIR=/test
$ envsubst '$ITERATION $RUN_ID $PROJECT_DIR' < prompt.md | head -5
# Atlas Agent

You are Atlas, an autonomous coding agent. Iteration 5 of run test.
Working directory: /test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)