### PR TITLE
feat: add local mode for non-git projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-01-19
+
+### Added
+- Local mode: Atlas now works without git repositories
+- Automatic detection of .git/ directory
+- GIT_MODE variable passed to prompt (true/false)
+
+### Changed
+- Algorithm conditionally skips git operations when GIT_MODE=false
+- No branches, commits, or PRs created in local mode
+- Progress.txt PR field optional in local mode
+
 ## [1.10.0] - 2026-01-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Atlas (Autonomous Task Loop Agent System) is a bash-based tool that automates task processing using Claude Code. It reads tasks from a markdown backlog, creates branches, implements code, runs quality gates, creates PRs, merges them, and tracks progress—all autonomously in a loop.
+Atlas (Autonomous Task Loop Agent System) is a bash-based tool that automates task processing using Claude Code. It reads tasks from a markdown backlog, implements code, runs quality gates, and tracks progress—all autonomously in a loop.
+
+**Modes:**
+- **Git mode** (auto-detected): Creates branches, PRs, commits, and merges
+- **Local mode** (no .git/): Changes stay in working directory, no git operations
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/juancruzrossi/atlas/main/install.sh
 ### Requirements
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
-- Git
+- Git (optional - enables branches, PRs, and commits)
 
 ---
 
@@ -96,20 +96,24 @@ export ATLAS_TELEGRAM_CHAT="id"     # Telegram chat ID
 ```
 for each iteration:
     1. Resume task in IN_PROGRESS, or pick first from TODO
-    2. Create branch: [type]/[TASK_ID]-[description]
-    3. Move to IN_PROGRESS + commit
+    2. [git] Create branch: [type]/[TASK_ID]-[description]
+    3. Move to IN_PROGRESS [git: + commit]
     4. Implement task
     5. Run quality gates (from CLAUDE.md)
-    6. Create PR → merge (squash) → return to main
-    7. Move to DONE + commit
+    6. [git] Create PR → merge (squash) → return to main
+    7. Move to DONE [git: + commit]
     8. Write to progress.txt and guardrails.md
     9. If error → move to DELAYED
    10. If no tasks → exit loop
 ```
 
+**Modes:**
+- **Git mode** (default): Full GitFlow with branches, PRs, and commits
+- **Local mode**: Works without git - changes stay in working directory
+
 **Features:**
 - Context files pre-loaded (backlog, guardrails, progress, CLAUDE.md)
-- Commits state changes immediately (crash recovery)
+- Commits state changes immediately (crash recovery) [git mode]
 - Stale tasks auto-reset to TODO after timeout
 
 ---

--- a/atlas.sh
+++ b/atlas.sh
@@ -213,6 +213,16 @@ log_activity "RUN START run=$RUN_TAG iterations=$MAX_ITERATIONS"
 
 reset_stale_tasks
 
+# Detect git mode
+if [[ -d "$PROJECT_DIR/.git" ]]; then
+    export GIT_MODE="true"
+else
+    export GIT_MODE="false"
+    echo "⚠️  No git repository detected - running in LOCAL MODE"
+    echo "   (no branches, commits, or PRs will be created)"
+    echo ""
+fi
+
 for i in $(seq 1 $MAX_ITERATIONS); do
     echo "═══ ITERATION $i/$MAX_ITERATIONS ═══"
 
@@ -251,7 +261,7 @@ for i in $(seq 1 $MAX_ITERATIONS); do
     export ITERATION="$i"
 
     # Process prompt.md with variable substitution
-    PROMPT_CONTENT=$(envsubst '$PROJECT_DIR $PROJECT_NAME $RUN_ID $ITERATION' < "$ATLAS_HOME/prompt.md")
+    PROMPT_CONTENT=$(envsubst '$PROJECT_DIR $PROJECT_NAME $RUN_ID $ITERATION $GIT_MODE' < "$ATLAS_HOME/prompt.md")
 
     # Build prompt with processed instructions inline
     PROMPT="CONTEXT_FILES:$CONTEXT_FILES

--- a/prompt.md
+++ b/prompt.md
@@ -2,6 +2,7 @@
 
 You are Atlas, an autonomous coding agent. Iteration $ITERATION of run $RUN_ID.
 Working directory: $PROJECT_DIR
+Mode: $GIT_MODE (true=GitFlow, false=Local)
 
 ## Setup (FIRST - MANDATORY)
 
@@ -25,9 +26,10 @@ Do NOT skip this step. Read files in parallel for efficiency.
    ELSE → go to step 8
 
 2. IF starting new task:
-   - Create branch: [type]/[TASK_ID]-[short-description]
    - Move task to IN_PROGRESS in backlog.md
-   - git add .atlas/backlog.md && git commit -m "chore: start [TASK_ID]"
+   - IF GIT_MODE=true:
+     - Create branch: [type]/[TASK_ID]-[short-description]
+     - git add .atlas/backlog.md && git commit -m "chore: start [TASK_ID]"
 
 3. Implement task completely
 
@@ -37,16 +39,16 @@ Do NOT skip this step. Read files in parallel for efficiency.
 
 5. IF quality gates FAIL → go to ERROR HANDLING
 
-6. Complete GitFlow (use /commit skill if available, else gh CLI, else git):
-   - Create PR with full description of changes
-   - Merge with squash
-   - Return to main branch
+6. IF GIT_MODE=true:
+   - Complete GitFlow: Create PR, merge with squash, return to main
+   ELSE:
+   - (skip - changes already in working directory)
 
 7. Finalize:
-   - Move task to DONE with date and PR number
+   - Move task to DONE with date (and PR number if GIT_MODE=true)
    - Append to progress.txt (see format below)
    - Add Sign to guardrails.md if you learned something useful
-   - git add .atlas/ && git commit -m "chore: complete [TASK_ID]"
+   - IF GIT_MODE=true: git add .atlas/ && git commit -m "chore: complete [TASK_ID]"
 
 8. Print summary (MANDATORY - see format below)
 ```
@@ -94,8 +96,10 @@ If build/test fails or task is blocked:
 1. Move task to DELAYED with reason in backlog.md
 2. Append to errors.log (see format below)
 3. Add Sign to guardrails.md if you learned something preventable
-4. git add .atlas/ && git commit -m "chore: delay [TASK_ID]"
-5. Return to main branch, go to step 8
+4. IF GIT_MODE=true:
+   - git add .atlas/ && git commit -m "chore: delay [TASK_ID]"
+   - Return to main branch
+5. Go to step 8
 
 ## File Formats
 
@@ -103,7 +107,7 @@ If build/test fails or task is blocked:
 ```
 ## [DATE] - [TASK_ID]: [Title]
 Summary: [1-2 sentences of what was done]
-PR: #[number]
+PR: #[number] (omit if local mode)
 Notes: [any gotchas for future iterations]
 ```
 
@@ -142,8 +146,8 @@ If TODO and IN_PROGRESS are both empty:
 - ONE task per iteration
 - READ context files BEFORE starting
 - WRITE to progress.txt and guardrails.md AFTER completing
-- ALWAYS commit state changes immediately
-- ALWAYS end on main branch
+- IF GIT_MODE=true: commit state changes immediately
+- IF GIT_MODE=true: end on main branch
 - ALWAYS print summary at the end
 
 ## Boundaries (CRITICAL)
@@ -153,7 +157,7 @@ If TODO and IN_PROGRESS are both empty:
 - Create analysis reports, architecture reviews, or similar artifacts
 - Add files that weren't requested in the task
 - Over-engineer or add features not in the task spec
-- Commit files unrelated to the current task
+- IF GIT_MODE=true: Commit files unrelated to the current task
 
 **ALWAYS do these:**
 - Stay focused on the specific task at hand


### PR DESCRIPTION
## Summary
- Atlas now works in projects without git repositories
- Auto-detects `.git/` directory and sets `GIT_MODE=true/false`
- Skips branches, commits, and PRs when in local mode
- Shows warning when running in local mode

## Changes
- **atlas.sh**: Detect `.git/`, export `GIT_MODE`, add to envsubst
- **prompt.md**: Conditional algorithm, error handling, rules based on `GIT_MODE`
- **README.md**: Git now optional in requirements, document both modes
- **CLAUDE.md**: Add modes description to project overview
- **CHANGELOG.md**: Document v1.11.0

## Test plan
- [ ] Run `atlas 1` in git project (should work as before)
- [ ] Run `atlas 1` in non-git directory (should show LOCAL MODE warning, no git ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)