### PR TITLE
feat: add Atlas skills with auto-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/integration-session.json` tracks active session state
 - All feature PRs target integration branch, not main
 - Integration PR stays as draft for final human review
+- **Atlas Skills**: Modular skills installed to `~/.claude/skills/`
+  - `atlas-integration-flow`: Integration branch workflow details
+  - `atlas-branching`: Branch naming, conventional commits, squash merge
+  - `atlas-guardrails`: Signs format, error handling, learning from failures
+  - `atlas-state`: backlog.md structure, progress.txt format, state transitions
+- Skills auto-installed on `atlas init` and `atlas update`
 
 ### Changed
 - Feature branches now created from integration branch
 - PRs merged with squash to integration
 - `atlas.sh` includes integration-session.json in context files
+- `atlas.sh` now installs skills to `~/.claude/skills/` on init and update
 
 ## [1.11.0] - 2026-01-19
 

--- a/atlas.sh
+++ b/atlas.sh
@@ -34,6 +34,18 @@ case "${1:-}" in
         [[ ! -f "$ACTIVITY_LOG" ]] && { echo "# Activity Log"; echo "Started: $(date '+%Y-%m-%d %H:%M:%S')"; echo ""; } > "$ACTIVITY_LOG" && echo "  Created: activity.log"
         [[ ! -f "$ERRORS_LOG" ]] && { echo "# Error Log"; echo ""; } > "$ERRORS_LOG" && echo "  Created: errors.log"
         [[ -d "$ATLAS_HOME/references" ]] && [[ ! -d "$ATLAS_DIR/references" ]] && cp -r "$ATLAS_HOME/references" "$ATLAS_DIR/" && echo "  Created: references/"
+
+        # Install Atlas skills to ~/.claude/skills/
+        if [[ -d "$ATLAS_HOME/skills" ]]; then
+            mkdir -p "${HOME}/.claude/skills"
+            for skill_dir in "$ATLAS_HOME/skills"/atlas-*; do
+                skill_name=$(basename "$skill_dir")
+                mkdir -p "${HOME}/.claude/skills/$skill_name"
+                cp -r "$skill_dir"/* "${HOME}/.claude/skills/$skill_name/" 2>/dev/null || true
+            done
+            echo "  Installed: Atlas skills to ~/.claude/skills/"
+        fi
+
         echo "✓ Initialized .atlas/ in $PROJECT_DIR"
         exit 0
         ;;
@@ -44,7 +56,7 @@ case "${1:-}" in
         OLD_VERSION=$(grep -m1 "^## \[[0-9]" "$ATLAS_HOME/CHANGELOG.md" 2>/dev/null | sed 's/## \[\(.*\)\].*/\1/' || echo "unknown")
 
         # Download all files silently
-        mkdir -p "$ATLAS_HOME/templates" "$ATLAS_HOME/references"
+        mkdir -p "$ATLAS_HOME/templates" "$ATLAS_HOME/references" "$ATLAS_HOME/skills"
         curl -fsSL "$REPO_URL/atlas.sh" -o "$ATLAS_HOME/atlas.sh" && chmod +x "$ATLAS_HOME/atlas.sh"
         curl -fsSL "$REPO_URL/prompt.md" -o "$ATLAS_HOME/prompt.md"
         curl -fsSL "$REPO_URL/plan_prompt.md" -o "$ATLAS_HOME/plan_prompt.md"
@@ -53,6 +65,15 @@ case "${1:-}" in
         curl -fsSL "$REPO_URL/notify-telegram.sh" -o "$ATLAS_HOME/notify-telegram.sh" && chmod +x "$ATLAS_HOME/notify-telegram.sh"
         for f in backlog.md progress.txt guardrails.md; do curl -fsSL "$REPO_URL/templates/$f" -o "$ATLAS_HOME/templates/$f" 2>/dev/null; done
         for f in GUARDRAILS.md CONTEXT_ENGINEERING.md; do curl -fsSL "$REPO_URL/references/$f" -o "$ATLAS_HOME/references/$f" 2>/dev/null; done
+
+        # Download and install Atlas skills
+        SKILLS="atlas-integration-flow atlas-branching atlas-guardrails atlas-state"
+        mkdir -p "${HOME}/.claude/skills"
+        for skill in $SKILLS; do
+            mkdir -p "$ATLAS_HOME/skills/$skill" "${HOME}/.claude/skills/$skill"
+            curl -fsSL "$REPO_URL/skills/$skill/SKILL.md" -o "$ATLAS_HOME/skills/$skill/SKILL.md" 2>/dev/null || true
+            [[ -f "$ATLAS_HOME/skills/$skill/SKILL.md" ]] && cp "$ATLAS_HOME/skills/$skill/SKILL.md" "${HOME}/.claude/skills/$skill/"
+        done
 
         # Update binary in PATH if needed
         ATLAS_BIN=$(which atlas 2>/dev/null)
@@ -66,6 +87,7 @@ case "${1:-}" in
         else
             echo "✓ Atlas updated: v$OLD_VERSION → v$NEW_VERSION"
         fi
+        echo "✓ Skills installed to ~/.claude/skills/"
         exit 0
         ;;
     plan)

--- a/skills/atlas-branching/SKILL.md
+++ b/skills/atlas-branching/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: atlas-branching
+description: |
+  Git branching conventions for Atlas autonomous agent. ONLY use when running
+  as Atlas agent. Covers: branch naming, conventional commits, PR workflow,
+  squash merge strategy. Use when: (1) creating branches, (2) writing commits,
+  (3) creating PRs, (4) merging PRs.
+author: Atlas
+version: 1.0.0
+date: 2026-01-19
+---
+
+# Atlas Branching Conventions
+
+**CRITICAL**: Only apply when running as Atlas agent with GIT_MODE=true.
+
+## Branch Naming
+
+Format: `[type]/[TASK_ID]-[short-description]`
+
+| Type | When |
+|------|------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `refactor/` | Code restructuring |
+| `test/` | Adding/fixing tests |
+| `docs/` | Documentation |
+| `chore/` | Maintenance tasks |
+
+**Examples**:
+```
+feature/HIGH-001-payment-system
+fix/BUG-042-login-redirect
+refactor/MED-015-api-client
+test/LOW-008-unit-tests
+```
+
+**Rules**:
+- Use TASK_ID from backlog.md
+- Lowercase, kebab-case
+- Max 50 chars for description part
+- No special characters except hyphens
+
+## Conventional Commits
+
+Format: `[type]: [description]`
+
+| Type | When |
+|------|------|
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `refactor:` | Code change (no feature/fix) |
+| `test:` | Tests only |
+| `docs:` | Documentation |
+| `chore:` | Maintenance (deps, config) |
+| `style:` | Formatting only |
+| `perf:` | Performance improvement |
+
+**Examples**:
+```
+feat: add payment processing endpoint
+fix: resolve null pointer in user service
+refactor: extract validation logic to service
+test: add unit tests for auth module
+chore: update dependencies
+```
+
+**Rules**:
+- Lowercase type
+- No period at end
+- Imperative mood ("add" not "added")
+- Max 72 chars total
+- Body optional, separated by blank line
+
+**DO NOT include**:
+- "Co-Authored-By: Claude" or similar
+- References to AI/Claude in commit messages
+- Emoji in commit messages
+
+## PR Workflow
+
+### Creating PR
+
+```bash
+# Push branch first
+git push -u origin [branch-name]
+
+# Create PR with gh CLI
+gh pr create \
+  --base [BASE_BRANCH] \
+  --title "[type]: [description]" \
+  --body "## Summary
+Brief description of changes.
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+How to test these changes.
+"
+```
+
+**PR Title**: Same format as conventional commits
+
+### Merging PR
+
+**ALWAYS use squash merge**:
+```bash
+gh pr merge --squash --delete-branch
+```
+
+Why squash:
+- Clean history on integration branch
+- One commit per feature/fix
+- Easier to review and revert
+
+### After Merge
+
+```bash
+# Return to base branch
+git checkout [BASE_BRANCH]
+git pull origin [BASE_BRANCH]
+```
+
+## State Commits
+
+Atlas uses special commits for state tracking:
+
+```bash
+# Starting a task
+git commit -m "chore: start [TASK_ID]"
+
+# Completing a task
+git commit -m "chore: complete [TASK_ID]"
+
+# Delaying a task
+git commit -m "chore: delay [TASK_ID]"
+```
+
+These commits include changes to `.atlas/` files only.
+
+## Common Mistakes
+
+**WRONG**:
+```bash
+git commit -m "Added new feature"        # Past tense
+git commit -m "Feat: Add feature"        # Capitalized type
+git commit -m "feat: add feature."       # Period at end
+git commit -m "feat add feature"         # Missing colon
+gh pr merge                              # Missing --squash
+```
+
+**CORRECT**:
+```bash
+git commit -m "feat: add payment endpoint"
+gh pr merge --squash --delete-branch
+```

--- a/skills/atlas-guardrails/SKILL.md
+++ b/skills/atlas-guardrails/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: atlas-guardrails
+description: |
+  Guardrails management for Atlas autonomous agent. ONLY use when running
+  as Atlas agent. Covers: Signs methodology, when to add guardrails, error
+  handling, learning from failures. Use when: (1) encountering errors,
+  (2) learning something useful, (3) reading guardrails.md.
+author: Atlas
+version: 1.0.0
+date: 2026-01-19
+---
+
+# Atlas Guardrails System
+
+**CRITICAL**: Only apply when running as Atlas agent.
+
+## Overview
+
+Guardrails are rules learned from past errors and discoveries. They prevent repeating mistakes and encode project-specific knowledge.
+
+Location: `.atlas/guardrails.md`
+
+## Sign Format
+
+When you learn something useful, add a Sign:
+
+```markdown
+### Sign: [Descriptive Name]
+- **Trigger**: [When to apply this rule]
+- **Instruction**: [What to do or avoid]
+- **Learned from**: [TASK_ID where this was learned]
+```
+
+**Example**:
+```markdown
+### Sign: Decimal Consistency
+- **Trigger**: Working with financial calculations in Python
+- **Instruction**: Always use Decimal, never float. Convert at API boundaries.
+- **Learned from**: MED-005
+```
+
+## When to Add Signs
+
+Add a Sign when you:
+
+1. **Fix a bug** that wasn't obvious
+2. **Discover a project pattern** that should be followed
+3. **Find a workaround** for a framework limitation
+4. **Learn a performance gotcha**
+5. **Identify a security consideration**
+
+**DO NOT add Signs for**:
+- Generic programming knowledge
+- Things already in CLAUDE.md
+- Temporary fixes that will be removed
+
+## Reading Guardrails
+
+**MANDATORY**: Read guardrails.md BEFORE starting any task.
+
+When you find a relevant Sign:
+1. Apply the instruction
+2. If the Sign is outdated, update it
+3. If the Sign conflicts with CLAUDE.md, CLAUDE.md wins
+
+## Error Handling
+
+When a task fails:
+
+### 1. Move to DELAYED
+
+In backlog.md, move task to DELAYED section with reason:
+
+```markdown
+### TASK-001: Feature description (DELAYED: 2026-01-19)
+- **Category:** feature
+- **Delay reason:** Build failed - missing dependency X
+```
+
+### 2. Log the Error
+
+Append to `.atlas/errors.log`:
+
+```
+[2026-01-19] TASK-001: Build failed - missing dependency X
+```
+
+Keep it brief. One line per error.
+
+### 3. Add Sign if Learnable
+
+If the error teaches something preventable:
+
+```markdown
+### Sign: Dependency X Required
+- **Trigger**: Using feature Y in this project
+- **Instruction**: Ensure dependency X is installed first
+- **Learned from**: TASK-001
+```
+
+### 4. Commit and Continue
+
+```bash
+git add .atlas/
+git commit -m "chore: delay TASK-001"
+git push
+```
+
+Then move to next task.
+
+## Sign Categories
+
+Organize Signs by type:
+
+```markdown
+# Guardrails
+
+## Build & Dependencies
+### Sign: Node Version
+- **Trigger**: Running npm commands
+- **Instruction**: Use Node 20+, check with `node -v`
+- **Learned from**: SETUP-001
+
+## API & Data
+### Sign: Date Formatting
+- **Trigger**: Sending dates to API
+- **Instruction**: Use ISO 8601 format YYYY-MM-DD
+- **Learned from**: BUG-015
+
+## Security
+### Sign: Environment Variables
+- **Trigger**: Adding new secrets
+- **Instruction**: Never commit .env, add to .env.example
+- **Learned from**: SEC-001
+```
+
+## Updating Signs
+
+If a Sign is wrong or outdated:
+
+1. Update the Sign content
+2. Update "Learned from" to current task
+3. Commit with message: `chore: update guardrail [Sign Name]`
+
+## Priority
+
+When instructions conflict:
+
+1. **CLAUDE.md** (project rules) - Highest
+2. **Feature Spec** (current task spec)
+3. **Guardrails.md** (learned rules)
+4. **General knowledge** - Lowest
+
+## Example guardrails.md
+
+```markdown
+# Guardrails
+
+Rules learned from past iterations. READ before starting any task.
+
+## API Patterns
+
+### Sign: UTC Dates
+- **Trigger**: Storing or comparing dates
+- **Instruction**: Always use UTC in backend, convert to local only in frontend
+- **Learned from**: BUG-023
+
+### Sign: Pagination Required
+- **Trigger**: Creating list endpoints
+- **Instruction**: Always implement pagination, default limit 50
+- **Learned from**: PERF-008
+
+## Frontend
+
+### Sign: No Transparency
+- **Trigger**: Creating UI components
+- **Instruction**: Use solid backgrounds (#121216), no glass effects
+- **Learned from**: UI-012
+
+## Testing
+
+### Sign: Mock External Services
+- **Trigger**: Writing tests that call external APIs
+- **Instruction**: Always mock, never call real APIs in tests
+- **Learned from**: TEST-005
+```

--- a/skills/atlas-integration-flow/SKILL.md
+++ b/skills/atlas-integration-flow/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: atlas-integration-flow
+description: |
+  Integration branch workflow for Atlas autonomous sessions. ONLY use when
+  running as Atlas agent (detected by GIT_MODE=true in prompt context).
+  Handles: creating integration branch, PR workflow to integration,
+  draft PR to main. Use when: (1) starting Atlas session with git,
+  (2) creating PRs during Atlas run, (3) completing Atlas session.
+author: Atlas
+version: 1.0.0
+date: 2026-01-19
+---
+
+# Atlas Integration Branch Flow
+
+**CRITICAL**: Only apply this workflow when running as Atlas agent with GIT_MODE=true.
+
+## Overview
+
+All Atlas work goes to an integration branch, NOT directly to main. This allows human review of all changes before merging to main.
+
+```
+main (protected)
+  │
+  └── integration/atlas-YYYYMMDD-HHMMSS  ← Draft PR to main (NO merge until review)
+        │
+        ├── feature/TASK-001  → PR to integration ✓ merged
+        ├── feature/TASK-002  → PR to integration ✓ merged
+        └── fix/TASK-003      → PR to integration ✓ merged
+```
+
+## Step 0: Initialize Integration Session
+
+**On first iteration** (when `.claude/integration-session.json` does NOT exist):
+
+```bash
+# 1. Generate session name
+SESSION_NAME="atlas-$(date +%Y%m%d-%H%M%S)"
+BASE_BRANCH="integration/$SESSION_NAME"
+
+# 2. Create integration branch from main
+git checkout main && git pull origin main
+git checkout -b "$BASE_BRANCH"
+git push -u origin "$BASE_BRANCH"
+
+# 3. Create draft PR to main (REQUIRED)
+PR_URL=$(gh pr create --draft --base main \
+  --title "🔄 Integration: $SESSION_NAME" \
+  --body "## Integration Branch
+
+⚠️ **NO MERGEAR** hasta revisión completa.
+
+### PRs incluidos
+_Se actualizará con cada feature mergeada_
+
+### Checklist
+- [ ] Code review completo
+- [ ] Tests passing
+- [ ] Sin conflictos con main
+")
+PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+# 4. Create session file
+mkdir -p .claude
+cat > .claude/integration-session.json << EOF
+{
+  "session_name": "$SESSION_NAME",
+  "branch": "$BASE_BRANCH",
+  "pr_number": $PR_NUMBER,
+  "status": "active",
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+# 5. Commit session file
+git add .claude/integration-session.json
+git commit -m "chore: init integration session $SESSION_NAME"
+git push
+```
+
+## Subsequent Iterations
+
+**When `.claude/integration-session.json` EXISTS**:
+
+```bash
+# Read existing session
+BASE_BRANCH=$(jq -r '.branch' .claude/integration-session.json)
+
+# Checkout and pull latest
+git checkout "$BASE_BRANCH"
+git pull origin "$BASE_BRANCH"
+```
+
+## Creating Feature Branches
+
+Always create from integration branch:
+
+```bash
+# CORRECT
+git checkout "$BASE_BRANCH"
+git pull origin "$BASE_BRANCH"
+git checkout -b feature/TASK-001-description
+
+# WRONG - never branch from main during Atlas session
+git checkout main  # NO!
+```
+
+## Creating PRs
+
+**Target integration branch, NOT main**:
+
+```bash
+# CORRECT
+gh pr create --base "$BASE_BRANCH" --title "feat: description"
+
+# WRONG
+gh pr create --base main  # NO! Never during Atlas session
+```
+
+## Merging PRs
+
+```bash
+# Squash merge to integration
+gh pr merge --squash --delete-branch
+
+# Return to integration branch
+git checkout "$BASE_BRANCH"
+git pull origin "$BASE_BRANCH"
+```
+
+## End of Session
+
+The integration branch stays with draft PR open to main. Human reviews and merges when ready.
+
+**DO NOT**:
+- Merge integration PR to main automatically
+- Mark integration PR as ready automatically
+- Delete integration branch before human review
+
+## Session File Format
+
+```json
+{
+  "session_name": "atlas-20260119-155537",
+  "branch": "integration/atlas-20260119-155537",
+  "pr_number": 28,
+  "status": "active",
+  "created_at": "2026-01-19T15:55:37Z"
+}
+```
+
+## Error Recovery
+
+If integration branch gets out of sync:
+```bash
+git checkout "$BASE_BRANCH"
+git pull origin "$BASE_BRANCH"
+# If conflicts, resolve them on integration branch
+```
+
+If session file is corrupted, check GitHub for the integration branch and PR number, then recreate the file.

--- a/skills/atlas-state/SKILL.md
+++ b/skills/atlas-state/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: atlas-state
+description: |
+  State file management for Atlas autonomous agent. ONLY use when running
+  as Atlas agent. Covers: backlog.md structure, progress.txt format,
+  errors.log format, activity.log. Use when: (1) moving tasks between states,
+  (2) logging progress, (3) recording errors.
+author: Atlas
+version: 1.0.0
+date: 2026-01-19
+---
+
+# Atlas State Management
+
+**CRITICAL**: Only apply when running as Atlas agent.
+
+## File Locations
+
+All state files live in `.atlas/` directory:
+
+```
+.atlas/
+├── backlog.md      # Task queue
+├── progress.txt    # Completed task history
+├── guardrails.md   # Learned rules
+├── errors.log      # Error history
+├── activity.log    # Run history (managed by atlas.sh)
+├── runs/           # Per-iteration logs
+└── specs/          # Feature specifications
+```
+
+## backlog.md Structure
+
+```markdown
+# [Project] Backlog
+
+## TODO
+
+### TASK-001: Task title
+- **Category:** feature|fix|refactor|test|docs|chore
+- **Spec:** .atlas/specs/spec-YYYYMMDD-HHMMSS.md (optional)
+- **Description:** Brief description (optional)
+
+### TASK-002: Another task
+- **Category:** fix
+
+## IN PROGRESS
+
+### TASK-003: Current task (STARTED: 2026-01-19)
+- **Category:** feature
+
+## DONE
+
+### TASK-004: Completed task (2026-01-19) - PR #123
+- **Category:** feature
+
+## DELAYED
+
+### TASK-005: Blocked task (DELAYED: 2026-01-19)
+- **Category:** feature
+- **Delay reason:** Missing API credentials
+```
+
+### Moving Tasks
+
+**TODO → IN PROGRESS**:
+```markdown
+# Before (in TODO)
+### TASK-001: Add feature
+
+# After (in IN PROGRESS)
+### TASK-001: Add feature (STARTED: 2026-01-19)
+```
+
+**IN PROGRESS → DONE**:
+```markdown
+# Before (in IN PROGRESS)
+### TASK-001: Add feature (STARTED: 2026-01-19)
+
+# After (in DONE)
+### TASK-001: Add feature (2026-01-19) - PR #45
+```
+
+**IN PROGRESS → DELAYED**:
+```markdown
+# Before (in IN PROGRESS)
+### TASK-001: Add feature (STARTED: 2026-01-19)
+
+# After (in DELAYED)
+### TASK-001: Add feature (DELAYED: 2026-01-19)
+- **Delay reason:** Build fails due to missing dependency
+```
+
+### Task Selection
+
+1. If task in IN PROGRESS → continue that task
+2. If no task in IN PROGRESS → pick FIRST task from TODO
+3. If TODO and IN PROGRESS empty → session complete
+
+**NEVER skip tasks. ALWAYS pick the first one.**
+
+## progress.txt Format
+
+Append after each completed task:
+
+```markdown
+## [DATE] - [TASK_ID]: [Title]
+Summary: [1-2 sentences of what was done]
+PR: #[number]
+Notes: [any gotchas for future iterations]
+```
+
+**Example**:
+```markdown
+## 2026-01-19 - HIGH-001: Create user authentication
+Summary: Implemented JWT auth with refresh tokens. Added login/logout endpoints.
+PR: #45
+Notes: Refresh token rotation requires Redis, see .env.example for config.
+
+## 2026-01-19 - HIGH-002: Add password reset
+Summary: Added forgot password flow with email verification.
+PR: #46
+Notes: Email templates in templates/email/. Requires SMTP config.
+```
+
+### What to Include
+
+- **Summary**: What was implemented, high-level
+- **PR**: The PR number for reference
+- **Notes**: Things future iterations should know
+
+### What NOT to Include
+
+- Code snippets (too verbose)
+- Full file paths (summarize instead)
+- Debug information
+- Time spent
+
+## errors.log Format
+
+One line per error:
+
+```
+[DATE] TASK_ID: Brief error description
+```
+
+**Examples**:
+```
+[2026-01-19] HIGH-003: Build failed - TypeScript error in UserService
+[2026-01-19] MED-007: Tests failed - Mock not configured for external API
+[2026-01-19] LOW-012: Blocked - Missing API credentials in .env
+```
+
+Keep it brief. Details go in progress.txt or guardrails.md.
+
+## State Commits
+
+After modifying state files, commit immediately:
+
+```bash
+# Starting task
+git add .atlas/backlog.md
+git commit -m "chore: start TASK-001"
+
+# Completing task
+git add .atlas/
+git commit -m "chore: complete TASK-001"
+
+# Delaying task
+git add .atlas/
+git commit -m "chore: delay TASK-001"
+```
+
+**IMPORTANT**: Push after commit when GIT_MODE=true:
+```bash
+git push
+```
+
+## Integration with Specs
+
+If task has a `**Spec:**` field, read that spec for full context:
+
+```markdown
+### HIGH-005: Implement payment flow
+- **Category:** feature
+- **Spec:** .atlas/specs/spec-20260119-143022.md
+```
+
+The spec contains:
+- Full requirements
+- Acceptance criteria
+- Technical decisions
+- Edge cases
+
+**ALWAYS read the spec before starting a task that has one.**
+
+## Session Complete
+
+When TODO and IN PROGRESS are both empty:
+
+1. Print summary
+2. Output `<promise>COMPLETE</promise>`
+3. Atlas loop will exit
+
+```markdown
+=== SUMMARY ===
+Task: [last task completed]
+Status: DONE
+Pending: 0
+Loop: COMPLETE
+
+<promise>COMPLETE</promise>
+```


### PR DESCRIPTION
## Summary

Adds modular Atlas skills that are auto-installed to `~/.claude/skills/`:

### Skills included
- **atlas-integration-flow**: Integration branch workflow details
- **atlas-branching**: Branch naming, conventional commits, squash merge
- **atlas-guardrails**: Signs format, error handling, learning from failures
- **atlas-state**: backlog.md structure, progress.txt format, state transitions

### Installation
Skills are installed automatically on:
- `atlas init` - from local `~/.atlas/skills/`
- `atlas update` - downloaded from GitHub and installed

### Changes
- Added `skills/` directory with 4 skill files
- Modified `atlas.sh` to install skills on init/update
- Updated CHANGELOG.md