### PR TITLE
fix: always start from main and cleanup merged integration sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.2] - 2026-01-19
+
+### Fixed
+- Integration session cleanup: now ALWAYS starts from main at each iteration
+- Detects merged integration PRs and auto-cleans stale session files
+- Removed attempt to commit cleanup to main (which would fail on protected branches)
+- Updated `atlas-integration-flow` skill with correct cleanup flow
+
 ## [1.12.1] - 2026-01-19
 
 ### Fixed

--- a/prompt.md
+++ b/prompt.md
@@ -30,13 +30,22 @@ Do NOT skip this step. Read files in parallel for efficiency.
 
 ```
 0. IF GIT_MODE=true:
-   - IF .claude/integration-session.json exists AND status=active:
-     - BASE_BRANCH = read 'branch' from JSON (e.g. integration/xxx)
-     - git checkout $BASE_BRANCH && git pull origin $BASE_BRANCH
-   - ELSE:
+   - FIRST: git checkout main && git pull origin main  ← ALWAYS start from main
+   - IF .claude/integration-session.json exists:
+     - PR_NUMBER = read 'pr_number' from JSON
+     - PR_STATE = gh pr view $PR_NUMBER --json state -q '.state'
+     - IF PR_STATE="MERGED":
+       - Delete local integration branch: git branch -D integration/... (ignore errors)
+       - Delete session file locally: rm .claude/integration-session.json
+       - (NO commit - main is likely protected; new session will have its own JSON)
+       → Continue to create new session below
+     - ELSE (PR still open):
+       - BASE_BRANCH = read 'branch' from JSON
+       - git checkout $BASE_BRANCH && git pull origin $BASE_BRANCH
+       → Skip to step 1
+   - Create new session (no session file OR session was cleaned up):
      - SESSION_NAME = "atlas-$(date +%Y%m%d-%H%M%S)"
      - BASE_BRANCH = "integration/$SESSION_NAME"
-     - git checkout main && git pull origin main
      - git checkout -b $BASE_BRANCH && git push -u origin $BASE_BRANCH
      - Create draft PR: gh pr create --draft --base main --title "🔄 Integration: $SESSION_NAME"
      - Save .claude/integration-session.json with session_name, branch, pr_number, status=active
@@ -172,7 +181,7 @@ If TODO and IN_PROGRESS are both empty:
 - READ context files BEFORE starting
 - WRITE to progress.txt and guardrails.md AFTER completing
 - IF GIT_MODE=true: commit and push state changes immediately
-- IF GIT_MODE=true: always end on $BASE_BRANCH (integration branch, NOT main)
+- IF GIT_MODE=true: during iteration, work on $BASE_BRANCH (not main); step 0 handles branch setup
 - IF GIT_MODE=true: all PRs go to integration branch, NEVER to main
 - ALWAYS print summary at the end
 

--- a/skills/atlas-integration-flow/SKILL.md
+++ b/skills/atlas-integration-flow/SKILL.md
@@ -29,17 +29,44 @@ main (protected)
         └── fix/TASK-003      → PR to integration ✓ merged
 ```
 
-## Step 0: Initialize Integration Session
+## Step 0: Start Every Iteration
 
-**On first iteration** (when `.claude/integration-session.json` does NOT exist):
+**CRITICAL**: ALWAYS start from main, then check for existing session.
+
+```bash
+# 1. ALWAYS start from main
+git checkout main && git pull origin main
+
+# 2. Check for existing session
+if [[ -f .claude/integration-session.json ]]; then
+  PR_NUMBER=$(jq -r '.pr_number' .claude/integration-session.json)
+  PR_STATE=$(gh pr view "$PR_NUMBER" --json state -q '.state')
+
+  if [[ "$PR_STATE" == "MERGED" ]]; then
+    # Session was merged - cleanup locally and create new
+    BRANCH=$(jq -r '.branch' .claude/integration-session.json)
+    git branch -D "$BRANCH" 2>/dev/null || true  # Delete local branch
+    rm .claude/integration-session.json  # Delete locally (no commit to main - it's protected)
+    # Continue to create new session below
+  else
+    # Session still active - use it
+    BASE_BRANCH=$(jq -r '.branch' .claude/integration-session.json)
+    git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"
+    # Skip to step 1
+  fi
+fi
+```
+
+## Creating New Integration Session
+
+**When no session exists** (first iteration or after cleanup):
 
 ```bash
 # 1. Generate session name
 SESSION_NAME="atlas-$(date +%Y%m%d-%H%M%S)"
 BASE_BRANCH="integration/$SESSION_NAME"
 
-# 2. Create integration branch from main
-git checkout main && git pull origin main
+# 2. Create integration branch (already on main from step 0)
 git checkout -b "$BASE_BRANCH"
 git push -u origin "$BASE_BRANCH"
 
@@ -78,18 +105,17 @@ git commit -m "chore: init integration session $SESSION_NAME"
 git push
 ```
 
-## Subsequent Iterations
+## Why Start from Main?
 
-**When `.claude/integration-session.json` EXISTS**:
+If you start directly on an old integration branch:
+1. The user may have already merged the PR on GitHub
+2. You'd be working on a stale branch
+3. New Atlas runs would start from the wrong base
 
-```bash
-# Read existing session
-BASE_BRANCH=$(jq -r '.branch' .claude/integration-session.json)
-
-# Checkout and pull latest
-git checkout "$BASE_BRANCH"
-git pull origin "$BASE_BRANCH"
-```
+By ALWAYS starting from main and checking PR state, we ensure:
+- Fresh state on every iteration start
+- Automatic cleanup of merged sessions
+- New sessions created from latest main
 
 ## Creating Feature Branches
 


### PR DESCRIPTION
## Summary
- Al inicio de cada iteración, SIEMPRE hace `git checkout main && git pull` primero
- Verifica si el PR de integración ya fue mergeado antes de usar la sesión existente
- Si fue mergeado: limpia la rama local y el archivo de sesión, crea nueva sesión
- Removido el intento de commitear cleanup a main (fallaría en branches protegidos)

## Test plan
- [ ] Correr `atlas 3` después de haber mergeado un PR de integración
- [ ] Verificar que empieza desde main y crea nueva sesión

🤖 Generated with [Claude Code](https://claude.com/claude-code)