### PR TITLE
feat: force checkout to main in bash before starting iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-01-20
+
+### Added
+- **CRITICAL**: atlas.sh now forces checkout to main before starting iterations
+- Automatic cleanup of merged integration sessions in bash (not dependent on model)
+- Validates git state before invoking Claude to prevent stale branch issues
+
+### Fixed
+- Model no longer needs to follow "checkout main first" instruction - bash enforces it
+- Prevents working on already-merged integration branches
+
 ## [1.13.0] - 2026-01-20
 
 ### Added

--- a/atlas.sh
+++ b/atlas.sh
@@ -240,6 +240,31 @@ reset_stale_tasks
 # Detect git mode
 if [[ -d "$PROJECT_DIR/.git" ]]; then
     export GIT_MODE="true"
+
+    # CRITICAL: Always start from main to ensure clean state
+    echo "📍 Ensuring clean git state..."
+    CURRENT_BRANCH=$(git branch --show-current)
+    if [[ "$CURRENT_BRANCH" != "main" ]]; then
+        echo "   Switching from '$CURRENT_BRANCH' to main..."
+        git checkout main 2>/dev/null || { echo "❌ Failed to checkout main"; exit 1; }
+    fi
+    git pull origin main 2>/dev/null || echo "   ⚠️  Could not pull (offline or no remote)"
+
+    # Check for merged integration session and cleanup
+    if [[ -f ".claude/integration-session.json" ]]; then
+        SESSION_PR=$(jq -r '.pr_number' .claude/integration-session.json 2>/dev/null)
+        if [[ -n "$SESSION_PR" && "$SESSION_PR" != "null" ]]; then
+            PR_STATE=$(gh pr view "$SESSION_PR" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+            if [[ "$PR_STATE" == "MERGED" ]]; then
+                echo "   🧹 Cleaning up merged integration session (PR #$SESSION_PR)..."
+                OLD_BRANCH=$(jq -r '.branch' .claude/integration-session.json 2>/dev/null)
+                [[ -n "$OLD_BRANCH" ]] && git branch -D "$OLD_BRANCH" 2>/dev/null || true
+                rm -f .claude/integration-session.json
+                echo "   ✓ Cleaned up. New session will be created."
+            fi
+        fi
+    fi
+    echo ""
 else
     export GIT_MODE="false"
     echo "⚠️  No git repository detected - running in LOCAL MODE"


### PR DESCRIPTION
## Summary
FIX CRÍTICO: atlas.sh ahora fuerza estado git limpio antes de invocar a Claude:
- Siempre hace checkout a main y pull al inicio
- Detecta y limpia sesiones de integración mergeadas automáticamente
- Ya no depende de que el modelo siga las instrucciones correctamente

Esto previene el bug donde el modelo seguía trabajando en ramas de integración
ya mergeadas, causando PRs que apuntan a ramas inexistentes.

## Test plan
- [ ] Correr Atlas después de haber mergeado un PR de integración
- [ ] Verificar que hace checkout a main automáticamente
- [ ] Verificar que limpia sesión mergeada

🤖 Generated with [Claude Code](https://claude.com/claude-code)