### PR TITLE
fix: simplify task counter to pending only, include in Telegram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Bash-verified task counter after each iteration (don't trust model's count)
-- Shows TODO, In Progress, and Done counts from backlog.md
-- Logs task counts to activity.log
+- Bash-verified pending task counter after each iteration (don't trust model's count)
+- Shows pending count in terminal and Telegram notifications
+- Logs pending count to activity.log
 
 ### Changed
 - CLAUDE.md: Added mandatory development workflow (branch → PR → merge)

--- a/atlas.sh
+++ b/atlas.sh
@@ -407,10 +407,13 @@ $PROMPT_CONTENT"
     # Bash-verified task count (don't trust model's count)
     read TODO_COUNT IN_PROGRESS_COUNT DONE_COUNT <<< $(count_tasks "$BACKLOG_FILE")
     echo ""
-    echo "📊 Backlog status (verified):"
-    echo "   TODO: $TODO_COUNT | In Progress: $IN_PROGRESS_COUNT | Done: $DONE_COUNT"
+    echo "📊 Pending: $TODO_COUNT (verified)"
 
-    log_activity "ITERATION $i END duration=${ITER_DURATION}s todo=$TODO_COUNT done=$DONE_COUNT"
+    # Append verified count to summary for Telegram
+    SUMMARY="$SUMMARY
+Pending: $TODO_COUNT (verified)"
+
+    log_activity "ITERATION $i END duration=${ITER_DURATION}s pending=$TODO_COUNT"
     send_notification "$i" "$SUMMARY"
 
     if echo "$OUTPUT" | grep -q "<promise>COMPLETE</promise>"; then


### PR DESCRIPTION
## Summary
- Solo muestra pendientes (no el desglose completo)
- Incluye conteo verificado en notificación de Telegram
- Output: `📊 Pending: 10 (verified)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)