### PR TITLE
fix: return to main branch on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-01-20
+
 ### Added
 - Bash-verified pending task counter after each iteration (don't trust model's count)
 - Shows pending count in terminal and Telegram notifications
 - Logs pending count to activity.log
+
+### Fixed
+- **CRITICAL**: Atlas now returns to main branch on exit (COMPLETE or MAX_ITERATIONS)
+- Prevents leaving user on integration/feature branch after run completes
 
 ### Changed
 - CLAUDE.md: Added mandatory development workflow (branch → PR → merge)

--- a/atlas.sh
+++ b/atlas.sh
@@ -419,12 +419,14 @@ Pending: $TODO_COUNT"
     if echo "$OUTPUT" | grep -q "<promise>COMPLETE</promise>"; then
         echo ""; echo "✅ ALL TASKS COMPLETED!"
         log_activity "RUN COMPLETE run=$RUN_TAG"
+        [[ "$GIT_MODE" == "true" ]] && git checkout main 2>/dev/null || true
         exit 0
     fi
 
     sleep 2
 done
 
+[[ "$GIT_MODE" == "true" ]] && git checkout main 2>/dev/null || true
 echo ""; echo "🤖 MAX ITERATIONS REACHED"
 log_activity "RUN END run=$RUN_TAG (max iterations)"
 exit 0


### PR DESCRIPTION
## Summary
- Atlas ahora vuelve a main al salir (COMPLETE o MAX_ITERATIONS)
- Previene dejar al usuario en rama de integración/feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)