### PR TITLE
refactor: move integration-session.json to .atlas/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.1] - 2026-01-20
+
+### Changed
+- Move `integration-session.json` from `.claude/` to `.atlas/` for consistency
+- All Atlas state files now live in `.atlas/` directory
+
 ## [1.15.0] - 2026-01-20
 
 ### Added

--- a/atlas.sh
+++ b/atlas.sh
@@ -277,15 +277,15 @@ if [[ -d "$PROJECT_DIR/.git" ]]; then
     git pull origin main 2>/dev/null || echo "   ⚠️  Could not pull (offline or no remote)"
 
     # Check for merged integration session and cleanup
-    if [[ -f ".claude/integration-session.json" ]]; then
-        SESSION_PR=$(jq -r '.pr_number' .claude/integration-session.json 2>/dev/null)
+    if [[ -f ".atlas/integration-session.json" ]]; then
+        SESSION_PR=$(jq -r '.pr_number' .atlas/integration-session.json 2>/dev/null)
         if [[ -n "$SESSION_PR" && "$SESSION_PR" != "null" ]]; then
             PR_STATE=$(gh pr view "$SESSION_PR" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
             if [[ "$PR_STATE" == "MERGED" ]]; then
                 echo "   🧹 Cleaning up merged integration session (PR #$SESSION_PR)..."
-                OLD_BRANCH=$(jq -r '.branch' .claude/integration-session.json 2>/dev/null)
+                OLD_BRANCH=$(jq -r '.branch' .atlas/integration-session.json 2>/dev/null)
                 [[ -n "$OLD_BRANCH" ]] && git branch -D "$OLD_BRANCH" 2>/dev/null || true
-                rm -f .claude/integration-session.json
+                rm -f .atlas/integration-session.json
                 echo "   ✓ Cleaned up. New session will be created."
             fi
         fi
@@ -319,8 +319,8 @@ for i in $(seq 1 $MAX_ITERATIONS); do
 - $ERRORS_LOG (recent failures)"
     [[ -f "CLAUDE.md" ]] && CONTEXT_FILES="$CONTEXT_FILES
 - CLAUDE.md (project rules and quality gates)"
-    [[ -f ".claude/integration-session.json" ]] && CONTEXT_FILES="$CONTEXT_FILES
-- .claude/integration-session.json (INTEGRATION SESSION - use branch as BASE_BRANCH)"
+    [[ -f ".atlas/integration-session.json" ]] && CONTEXT_FILES="$CONTEXT_FILES
+- .atlas/integration-session.json (INTEGRATION SESSION - use branch as BASE_BRANCH)"
 
     # Extract spec file from current task in backlog (if exists)
     SPEC_FILE=""

--- a/skills/atlas-integration-flow/SKILL.md
+++ b/skills/atlas-integration-flow/SKILL.md
@@ -38,19 +38,19 @@ main (protected)
 git checkout main && git pull origin main
 
 # 2. Check for existing session
-if [[ -f .claude/integration-session.json ]]; then
-  PR_NUMBER=$(jq -r '.pr_number' .claude/integration-session.json)
+if [[ -f .atlas/integration-session.json ]]; then
+  PR_NUMBER=$(jq -r '.pr_number' .atlas/integration-session.json)
   PR_STATE=$(gh pr view "$PR_NUMBER" --json state -q '.state')
 
   if [[ "$PR_STATE" == "MERGED" ]]; then
     # Session was merged - cleanup locally and create new
-    BRANCH=$(jq -r '.branch' .claude/integration-session.json)
+    BRANCH=$(jq -r '.branch' .atlas/integration-session.json)
     git branch -D "$BRANCH" 2>/dev/null || true  # Delete local branch
-    rm .claude/integration-session.json  # Delete locally (no commit to main - it's protected)
+    rm .atlas/integration-session.json  # Delete locally (no commit to main - it's protected)
     # Continue to create new session below
   else
     # Session still active - use it
-    BASE_BRANCH=$(jq -r '.branch' .claude/integration-session.json)
+    BASE_BRANCH=$(jq -r '.branch' .atlas/integration-session.json)
     git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"
     # Skip to step 1
   fi
@@ -87,9 +87,8 @@ _Se actualizará con cada feature mergeada_
 ")
 PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 
-# 4. Create session file
-mkdir -p .claude
-cat > .claude/integration-session.json << EOF
+# 4. Create session file (.atlas/ already exists from atlas init)
+cat > .atlas/integration-session.json << EOF
 {
   "session_name": "$SESSION_NAME",
   "branch": "$BASE_BRANCH",
@@ -100,7 +99,7 @@ cat > .claude/integration-session.json << EOF
 EOF
 
 # 5. Commit session file
-git add .claude/integration-session.json
+git add .atlas/integration-session.json
 git commit -m "chore: init integration session $SESSION_NAME"
 git push
 ```


### PR DESCRIPTION
## Summary
- Move `integration-session.json` from `.claude/` to `.atlas/` for consistency
- All Atlas state files now live in `.atlas/` directory
- Updated `atlas.sh` and `atlas-integration-flow` skill

## Test plan
- [ ] Run `atlas init` on a new project
- [ ] Run `atlas 1` and verify session file is created in `.atlas/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)