### PR TITLE
docs: add ATLAS_DEFAULT_BRANCH to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.7] - 2026-01-20
+
+### Added
+- Document `ATLAS_DEFAULT_BRANCH` env var in README and CLAUDE.md
+
 ## [1.15.6] - 2026-01-20
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ This is a pure bash project. No build step required.
 - `ATLAS_MAX_ITERATIONS` - Max iterations per run (default: 25)
 - `ATLAS_TIMEOUT` - Timeout per iteration in seconds (default: 1200)
 - `ATLAS_STALE_SECONDS` - Reset stuck tasks after N seconds (default: 7200)
+- `ATLAS_DEFAULT_BRANCH` - Override auto-detected default branch (default: auto)
 - `ATLAS_NOTIFY_TELEGRAM` - Enable Telegram notifications (default: true)
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Override defaults with `ATLAS_` environment variables:
 export ATLAS_MAX_ITERATIONS=25      # Max iterations per run
 export ATLAS_TIMEOUT=1200           # Timeout per iteration (seconds)
 export ATLAS_STALE_SECONDS=7200     # Reset stuck tasks (seconds, 0 to disable)
+export ATLAS_DEFAULT_BRANCH=main    # Override auto-detected default branch
 export ATLAS_NOTIFY_TELEGRAM=true   # Enable Telegram notifications
 export ATLAS_TELEGRAM_BOT="token"   # Telegram bot token
 export ATLAS_TELEGRAM_CHAT="id"     # Telegram chat ID


### PR DESCRIPTION
## Summary
- Add `ATLAS_DEFAULT_BRANCH` env var to README configuration section
- Add `ATLAS_DEFAULT_BRANCH` to CLAUDE.md key environment variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)