### PR TITLE
fix: error handling returns tasks to TODO, not DELAYED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.8] - 2026-01-20
+
+### Fixed
+- Error handling: failed tasks now return to TODO (retry), not DELAYED
+- DELAYED section is only for tasks explicitly postponed by decision
+
 ## [1.15.7] - 2026-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ for each iteration:
     6. [git] Create PR → merge (squash) to integration branch
     7. Move to DONE [git: + commit]
     8. Write to progress.txt and guardrails.md
-    9. If error → move to DELAYED
+    9. If error → log to errors.log, move back to TODO
    10. If no tasks → exit loop
 ```
 

--- a/prompt.md
+++ b/prompt.md
@@ -128,14 +128,16 @@ semgrep scan --config auto --error --severity ERROR
 
 ## Error Handling
 
-If build/test fails or task is blocked:
-1. Move task to DELAYED with reason in backlog.md
+If build/test fails:
+1. Move task back to TODO (will retry next iteration)
 2. Append to errors.log (see format below)
 3. Add Sign to guardrails.md if you learned something preventable
 4. IF GIT_MODE=true:
-   - git add .atlas/ && git commit -m "chore: delay [TASK_ID]" && git push
+   - git add .atlas/ && git commit -m "chore: error [TASK_ID]" && git push
    - Discard feature branch: git checkout $BASE_BRANCH && git branch -D [feature-branch]
 5. Go to step 8
+
+**Note:** DELAYED is only for tasks explicitly postponed by decision, not for errors.
 
 ## File Formats
 


### PR DESCRIPTION
## Summary
- Failed tasks now return to TODO for retry, not DELAYED
- DELAYED section is only for tasks explicitly postponed by decision

## Changed files
- README.md: Updated "How It Works" section
- prompt.md: Updated error handling instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)