### PR TITLE
fix: improve git checkout error handling with clear messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-01-21
+
+### Fixed
+- Git checkout now shows actual error message instead of generic "Failed to checkout"
+- Handle uncommitted changes gracefully with clear message and status output
+- Handle repos without local default branch (creates from remote if available)
+- Handle new repos with no commits yet (skips branch check entirely)
+
 ## [1.16.0] - 2026-01-21
 
 ### Added

--- a/atlas.sh
+++ b/atlas.sh
@@ -276,9 +276,39 @@ if [[ -d "$PROJECT_DIR/.git" ]]; then
     # CRITICAL: Always start from default branch to ensure clean state
     echo "📍 Ensuring clean git state..."
     CURRENT_BRANCH=$(git branch --show-current)
-    if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
+
+    # Handle empty repo (no commits yet) - skip branch switching
+    if [[ -z "$CURRENT_BRANCH" ]] && ! git rev-parse HEAD &>/dev/null; then
+        echo "   ⚠️  New repository with no commits yet - skipping branch check"
+    elif [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
         echo "   Switching from '$CURRENT_BRANCH' to $DEFAULT_BRANCH..."
-        git checkout "$DEFAULT_BRANCH" 2>/dev/null || { echo "❌ Failed to checkout $DEFAULT_BRANCH"; exit 1; }
+
+        # Check for uncommitted changes that would block checkout
+        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+            echo "❌ Cannot switch branches: you have uncommitted changes"
+            echo "   Please commit or stash your changes first:"
+            git status --short
+            exit 1
+        fi
+
+        # Try checkout, showing the actual error if it fails
+        if ! git checkout "$DEFAULT_BRANCH" 2>&1; then
+            # Branch might not exist locally - try to create from remote
+            if git show-ref --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH" 2>/dev/null; then
+                echo "   Creating local branch from origin/$DEFAULT_BRANCH..."
+                git checkout -b "$DEFAULT_BRANCH" "origin/$DEFAULT_BRANCH" || {
+                    echo "❌ Failed to create local branch $DEFAULT_BRANCH"
+                    exit 1
+                }
+            else
+                echo "❌ Branch '$DEFAULT_BRANCH' does not exist locally or on remote"
+                echo "   Available branches:"
+                git branch -a
+                echo ""
+                echo "   Hint: Set ATLAS_DEFAULT_BRANCH to your main branch name, or create the branch first"
+                exit 1
+            fi
+        fi
     fi
     git pull origin "$DEFAULT_BRANCH" 2>/dev/null || echo "   ⚠️  Could not pull (offline or no remote)"
 


### PR DESCRIPTION
## Summary
- Show actual git error instead of generic "Failed to checkout main"
- Check for uncommitted changes before attempting checkout (with status output)
- Create local branch from remote if it doesn't exist locally
- Skip branch check for new repos without any commits

## Test plan
- [ ] Run `atlas 1` in repo with uncommitted changes - should show clear error
- [ ] Run `atlas 1` in repo without local main branch - should create from remote
- [ ] Run `atlas 1` in new repo with no commits - should skip branch check

🤖 Generated with [Claude Code](https://claude.com/claude-code)