### PR TITLE
feat: add .gitignore to .atlas/ for session logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.2] - 2026-01-21
+
+### Added
+- `atlas init` now creates `.atlas/.gitignore` to exclude session logs from git tracking
+- Logs (`activity.log`, `errors.log`, `runs/`) stay local for debugging, won't appear as uncommitted changes
+
 ## [1.16.1] - 2026-01-21
 
 ### Fixed

--- a/atlas.sh
+++ b/atlas.sh
@@ -33,6 +33,19 @@ case "${1:-}" in
         [[ ! -f "$GUARDRAILS_FILE" ]] && cp "$ATLAS_HOME/templates/guardrails.md" "$GUARDRAILS_FILE" && echo "  Created: guardrails.md"
         [[ ! -f "$ACTIVITY_LOG" ]] && { echo "# Activity Log"; echo "Started: $(date '+%Y-%m-%d %H:%M:%S')"; echo ""; } > "$ACTIVITY_LOG" && echo "  Created: activity.log"
         [[ ! -f "$ERRORS_LOG" ]] && { echo "# Error Log"; echo ""; } > "$ERRORS_LOG" && echo "  Created: errors.log"
+        # Create .gitignore to exclude session logs (they're local debugging, not code)
+        if [[ ! -f "$ATLAS_DIR/.gitignore" ]]; then
+            cat > "$ATLAS_DIR/.gitignore" << 'GITIGNORE'
+# Atlas session logs (local debugging files)
+activity.log
+errors.log
+runs/
+
+# Keep integration session tracked (needed for PR workflow)
+!integration-session.json
+GITIGNORE
+            echo "  Created: .gitignore"
+        fi
         [[ -d "$ATLAS_HOME/references" ]] && [[ ! -d "$ATLAS_DIR/references" ]] && cp -r "$ATLAS_HOME/references" "$ATLAS_DIR/" && echo "  Created: references/"
 
         # Install Atlas skills to ~/.claude/skills/


### PR DESCRIPTION
## Summary
- `atlas init` now creates `.atlas/.gitignore` automatically
- Excludes `activity.log`, `errors.log`, and `runs/` from git tracking
- These are local debugging files, not code
- Prevents "uncommitted changes" confusion after atlas sessions end

## Context
After atlas finishes a session, logs were left uncommitted, causing confusion ("why are there changes?"). Now they're gitignored.

## Test plan
- [ ] Run `atlas init` in new project → should create `.atlas/.gitignore`
- [ ] Run `atlas 1` → logs should NOT appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)