### PR TITLE
fix: integration PR Ready for Review, enforce task rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.3] - 2026-01-23
+
+### Fixed
+- **Integration PR now Ready for Review** instead of Draft - allows immediate review when ready
+- **Task movement rules enforced**: Only ONE task can be in IN_PROGRESS at a time
+- Tasks must stay in TODO until work begins, then move to IN_PROGRESS one at a time
+- Corrected atlas-guardrails skill: errors move to TODO (retry), not DELAYED
+
+### Changed
+- All Atlas skills updated to v1.1.0 with clearer invocation guidance
+- Skills now explicitly document they should be invoked by Atlas specialized agents
+
 ## [1.16.2] - 2026-01-21
 
 ### Added

--- a/prompt.md
+++ b/prompt.md
@@ -47,14 +47,14 @@ Do NOT skip this step. Read files in parallel for efficiency.
      - SESSION_NAME = "atlas-$(date +%Y%m%d-%H%M%S)"
      - BASE_BRANCH = "integration/$SESSION_NAME"
      - git checkout -b $BASE_BRANCH && git push -u origin $BASE_BRANCH
-     - **CRITICAL**: Create draft PR to main IMMEDIATELY after creating branch:
-       gh pr create --draft --base main --title "🔄 Integration: $SESSION_NAME" --body "..."
+     - **CRITICAL**: Create PR to main IMMEDIATELY after creating branch (Ready for Review, NOT draft):
+       gh pr create --base main --title "🔄 Integration: $SESSION_NAME" --body "..."
      - Capture PR_NUMBER from gh pr create output
      - Save .atlas/integration-session.json with session_name, branch, pr_number, status=active
      - git add .atlas/ && git commit -m "chore: init integration session" && git push
 
-1. IF task in IN_PROGRESS → continue it
-   ELSE IF task in TODO → pick FIRST one
+1. IF task in IN_PROGRESS → continue it (ONLY ONE task can be in IN_PROGRESS at a time)
+   ELSE IF task in TODO → pick FIRST one (do NOT move multiple tasks)
    ELSE → go to step 8
 
 2. IF starting new task:
@@ -182,6 +182,8 @@ If TODO and IN_PROGRESS are both empty:
 ## Rules
 
 - ONE task per iteration
+- ONLY ONE task in IN_PROGRESS at any time - NEVER move multiple tasks to IN_PROGRESS
+- Tasks start in TODO → move to IN_PROGRESS only when starting work → move to DONE when complete
 - READ context files BEFORE starting
 - WRITE to progress.txt and guardrails.md AFTER completing
 - IF GIT_MODE=true: commit and push state changes immediately

--- a/skills/atlas-branching/SKILL.md
+++ b/skills/atlas-branching/SKILL.md
@@ -5,9 +5,11 @@ description: |
   as Atlas agent. Covers: branch naming, conventional commits, PR workflow,
   squash merge strategy. Use when: (1) creating branches, (2) writing commits,
   (3) creating PRs, (4) merging PRs.
+
+  IMPORTANT: When using Atlas specialized agents, invoke this skill for branching conventions.
 author: Atlas
-version: 1.0.0
-date: 2026-01-19
+version: 1.1.0
+date: 2026-01-23
 ---
 
 # Atlas Branching Conventions

--- a/skills/atlas-guardrails/SKILL.md
+++ b/skills/atlas-guardrails/SKILL.md
@@ -5,9 +5,11 @@ description: |
   as Atlas agent. Covers: Signs methodology, when to add guardrails, error
   handling, learning from failures. Use when: (1) encountering errors,
   (2) learning something useful, (3) reading guardrails.md.
+
+  IMPORTANT: When using Atlas specialized agents, invoke this skill for guardrails management.
 author: Atlas
-version: 1.0.0
-date: 2026-01-19
+version: 1.1.0
+date: 2026-01-23
 ---
 
 # Atlas Guardrails System
@@ -67,15 +69,16 @@ When you find a relevant Sign:
 
 When a task fails:
 
-### 1. Move to DELAYED
+### 1. Move Back to TODO
 
-In backlog.md, move task to DELAYED section with reason:
+In backlog.md, move task back to TODO section (will be retried next iteration):
 
 ```markdown
-### TASK-001: Feature description (DELAYED: 2026-01-19)
+### TASK-001: Feature description
 - **Category:** feature
-- **Delay reason:** Build failed - missing dependency X
 ```
+
+**Note:** DELAYED is only for tasks explicitly postponed by decision, not for build/test errors.
 
 ### 2. Log the Error
 
@@ -102,11 +105,11 @@ If the error teaches something preventable:
 
 ```bash
 git add .atlas/
-git commit -m "chore: delay TASK-001"
+git commit -m "chore: error TASK-001"
 git push
 ```
 
-Then move to next task.
+Then move to next task (or retry the same task if it's first in TODO).
 
 ## Sign Categories
 

--- a/skills/atlas-integration-flow/SKILL.md
+++ b/skills/atlas-integration-flow/SKILL.md
@@ -4,11 +4,13 @@ description: |
   Integration branch workflow for Atlas autonomous sessions. ONLY use when
   running as Atlas agent (detected by GIT_MODE=true in prompt context).
   Handles: creating integration branch, PR workflow to integration,
-  draft PR to main. Use when: (1) starting Atlas session with git,
+  PR to main (Ready for Review). Use when: (1) starting Atlas session with git,
   (2) creating PRs during Atlas run, (3) completing Atlas session.
+
+  IMPORTANT: When using Atlas specialized agents, invoke this skill for git operations.
 author: Atlas
-version: 1.0.0
-date: 2026-01-19
+version: 1.1.0
+date: 2026-01-23
 ---
 
 # Atlas Integration Branch Flow
@@ -22,7 +24,7 @@ All Atlas work goes to an integration branch, NOT directly to main. This allows 
 ```
 main (protected)
   │
-  └── integration/atlas-YYYYMMDD-HHMMSS  ← Draft PR to main (NO merge until review)
+  └── integration/atlas-YYYYMMDD-HHMMSS  ← PR to main (Ready for Review, NO merge until review)
         │
         ├── feature/TASK-001  → PR to integration ✓ merged
         ├── feature/TASK-002  → PR to integration ✓ merged
@@ -70,8 +72,8 @@ BASE_BRANCH="integration/$SESSION_NAME"
 git checkout -b "$BASE_BRANCH"
 git push -u origin "$BASE_BRANCH"
 
-# 3. Create draft PR to main (REQUIRED)
-PR_URL=$(gh pr create --draft --base main \
+# 3. Create PR to main - Ready for Review, NOT draft (REQUIRED)
+PR_URL=$(gh pr create --base main \
   --title "🔄 Integration: $SESSION_NAME" \
   --body "## Integration Branch
 
@@ -155,11 +157,10 @@ git pull origin "$BASE_BRANCH"
 
 ## End of Session
 
-The integration branch stays with draft PR open to main. Human reviews and merges when ready.
+The integration branch stays with PR open to main (Ready for Review). Human reviews and merges when ready.
 
 **DO NOT**:
 - Merge integration PR to main automatically
-- Mark integration PR as ready automatically
 - Delete integration branch before human review
 
 ## Session File Format

--- a/skills/atlas-state/SKILL.md
+++ b/skills/atlas-state/SKILL.md
@@ -5,9 +5,14 @@ description: |
   as Atlas agent. Covers: backlog.md structure, progress.txt format,
   errors.log format, activity.log. Use when: (1) moving tasks between states,
   (2) logging progress, (3) recording errors.
+
+  CRITICAL: Only ONE task can be in IN_PROGRESS at a time. Tasks start in TODO,
+  move to IN_PROGRESS when work begins, then to DONE when complete.
+
+  IMPORTANT: When using Atlas specialized agents, invoke this skill for state management.
 author: Atlas
-version: 1.0.0
-date: 2026-01-19
+version: 1.1.0
+date: 2026-01-23
 ---
 
 # Atlas State Management
@@ -97,7 +102,11 @@ All state files live in `.atlas/` directory:
 2. If no task in IN_PROGRESS → pick FIRST task from TODO
 3. If TODO and IN_PROGRESS empty → session complete
 
-**NEVER skip tasks. ALWAYS pick the first one.**
+**CRITICAL RULES:**
+- **ONLY ONE** task can be in IN_PROGRESS at any time
+- **NEVER** move multiple tasks to IN_PROGRESS
+- **NEVER** skip tasks - ALWAYS pick the first one from TODO
+- Tasks flow: TODO → IN_PROGRESS → DONE (one at a time)
 
 ## progress.txt Format
 


### PR DESCRIPTION
## Summary
- Integration branch PR now created as **Ready for Review** instead of Draft
- Enforced: **only ONE task** can be in IN_PROGRESS at any time
- Tasks must stay in TODO until work begins, then move one at a time
- Fixed atlas-guardrails: errors move back to TODO (retry), not DELAYED
- All Atlas skills updated to v1.1.0 with clearer invocation guidance

## Changes
- `prompt.md`: Removed `--draft`, added explicit task rules
- `skills/atlas-integration-flow/SKILL.md`: Removed draft, updated docs
- `skills/atlas-state/SKILL.md`: Added critical task movement rules
- `skills/atlas-branching/SKILL.md`: Added invocation guidance
- `skills/atlas-guardrails/SKILL.md`: Fixed error handling (TODO not DELAYED)
- `CHANGELOG.md`: Added v1.16.3

## Test Plan
- [ ] Run `atlas update` to get new version
- [ ] Run `atlas 1` and verify integration PR is Ready for Review
- [ ] Verify only one task moves to IN_PROGRESS at a time