### PR TITLE
fix: macOS compatibility for timeout command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **macOS compatibility** - Fixed `timeout: command not found` error on macOS by using cross-platform timeout detection
+
 ## [1.17.0] - 2026-02-02
 
 ### Added

--- a/atlas.sh
+++ b/atlas.sh
@@ -18,6 +18,28 @@ PROGRESS_FILE="$ATLAS_DIR/progress.txt"
 GUARDRAILS_FILE="$ATLAS_DIR/guardrails.md"
 BACKLOG_FILE="$ATLAS_DIR/backlog.md"
 
+# Cross-platform timeout function
+run_with_timeout() {
+    local timeout_seconds=$1
+    shift
+
+    # Try GNU timeout (Linux)
+    if command -v timeout >/dev/null 2>&1; then
+        timeout --foreground "$timeout_seconds" "$@"
+        return $?
+    fi
+
+    # Try gtimeout (macOS with brew install coreutils)
+    if command -v gtimeout >/dev/null 2>&1; then
+        gtimeout --foreground "$timeout_seconds" "$@"
+        return $?
+    fi
+
+    # Fallback: run without timeout (macOS without coreutils)
+    "$@"
+    return $?
+}
+
 case "${1:-}" in
     init)
         mkdir -p "$ATLAS_DIR" "$RUNS_DIR"
@@ -443,7 +465,7 @@ $PROMPT_CONTENT"
         RETRY_COUNT=$((RETRY_COUNT + 1))
 
         # Run claude and capture output
-        OUTPUT=$(timeout --foreground "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p < "$PROMPT_FILE_TMP" 2>&1) || true
+        OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p < "$PROMPT_FILE_TMP" 2>&1) || true
 
         # Check for CLI errors
         CLI_ERROR=""


### PR DESCRIPTION
## Summary
Fixes `timeout: command not found` error on macOS.

## Changes
- Added cross-platform `run_with_timeout` function
- Detects `timeout` (Linux) or `gtimeout` (macOS with coreutils)
- Falls back to no timeout if neither is available
- Updated CHANGELOG.md

## Testing
Tested on macOS without coreutils installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)