### PR TITLE
release: v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.1] - 2026-02-02
+
 ### Fixed
 - **macOS compatibility** - Fixed `timeout: command not found` error on macOS by using cross-platform timeout detection
 


### PR DESCRIPTION
## v1.17.1 - 2026-02-02

### Fixed
- **macOS compatibility** - Fixed `timeout: command not found` error on macOS by using cross-platform timeout detection

## Context
The `timeout` command was introduced on Jan 15 but only exists on Linux by default. This release adds automatic detection for:
- `timeout` (Linux)
- `gtimeout` (macOS with coreutils)
- Fallback to no timeout if neither is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)