### PR TITLE
fix: correct OpenCode invocation syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-02-02
+
+### Fixed
+- **OpenCode invocation syntax** - Fixed "You must provide a message or a command" error by passing prompt content as argument instead of using `--file` flag
+
 ## [2.0.0] - 2026-02-02
 
 ### Added

--- a/atlas.sh
+++ b/atlas.sh
@@ -573,7 +573,7 @@ $PROMPT_CONTENT"
         # Run AI CLI and capture output
         if [[ "$ATLAS_CLI" == "opencode" ]]; then
             export OPENCODE_PERMISSION='{"*":"allow"}'
-            OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" opencode run --agent build --file "$PROMPT_FILE_TMP" 2>&1) || true
+            OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" opencode run --agent build "$(cat "$PROMPT_FILE_TMP")" 2>&1) || true
         else
             OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p < "$PROMPT_FILE_TMP" 2>&1) || true
         fi


### PR DESCRIPTION
## Summary
Fixes OpenCode CLI invocation error.

## Problem
Running atlas --cli opencode 1 failed with: Error: You must provide a message or a command

## Solution
Changed invocation from using --file flag to passing prompt content as argument

## Testing
- Syntax validated with bash -n atlas.sh