### PR TITLE
fix: enforce backlog update after PR merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-02-03
+
+### Fixed
+- **CRITICAL: Backlog update enforcement** - Tasks were being completed (PRs merged) but not moved to DONE in backlog.md, causing state drift
+- Step 7 (Finalize) now marked as CRITICAL with explicit verification requirement
+- Added "CRITICAL: Update Backlog After Merge" section to `atlas-integration-flow` skill
+- Added verification rules to `atlas-state` skill: must confirm task in DONE before starting next task
+- Root cause: Model was merging PRs but skipping the backlog update step, leaving completed tasks in TODO
+
 ## [2.0.1] - 2026-02-02
 
 ### Fixed

--- a/prompt.md
+++ b/prompt.md
@@ -80,11 +80,12 @@ Do NOT skip this step. Read files in parallel for efficiency.
    ELSE:
    - (skip - changes already in working directory)
 
-7. Finalize:
-   - Move task to DONE with date (and PR number if GIT_MODE=true)
-   - Append to progress.txt (see format below)
+7. **CRITICAL - Finalize (NEVER SKIP)**:
+   - **MUST** move task from IN_PROGRESS to DONE in backlog.md with date and PR number
+   - **MUST** append to progress.txt (see format below)
    - Add Sign to guardrails.md if you learned something useful
    - IF GIT_MODE=true: git add .atlas/ && git commit -m "chore: complete [TASK_ID]" && git push
+   - **VERIFY**: Task MUST appear in DONE section before proceeding
 
 8. Print summary (MANDATORY - see format below)
 ```

--- a/skills/atlas-integration-flow/SKILL.md
+++ b/skills/atlas-integration-flow/SKILL.md
@@ -155,6 +155,27 @@ git checkout "$BASE_BRANCH"
 git pull origin "$BASE_BRANCH"
 ```
 
+## CRITICAL: Update Backlog After Merge
+
+**IMMEDIATELY after merging a PR, you MUST update the backlog:**
+
+```bash
+# 1. Move task from IN_PROGRESS to DONE in backlog.md
+#    Add completion date and PR number
+
+# 2. Append to progress.txt with summary
+
+# 3. Commit and push state changes
+git add .atlas/
+git commit -m "chore: complete [TASK_ID]"
+git push
+```
+
+**NEVER proceed to the next task without updating the backlog.**
+This is the most common source of state drift - tasks get completed but backlog shows them as pending.
+
+**Verification**: Before starting a new task, confirm the previous task appears in the DONE section of backlog.md.
+
 ## End of Session
 
 The integration branch stays with PR open to main (Ready for Review). Human reviews and merges when ready.

--- a/skills/atlas-state/SKILL.md
+++ b/skills/atlas-state/SKILL.md
@@ -107,6 +107,9 @@ All state files live in `.atlas/` directory:
 - **NEVER** move multiple tasks to IN_PROGRESS
 - **NEVER** skip tasks - ALWAYS pick the first one from TODO
 - Tasks flow: TODO → IN_PROGRESS → DONE (one at a time)
+- **NEVER** proceed to next task without moving current task to DONE
+- **ALWAYS** update backlog.md IMMEDIATELY after merging PR
+- **VERIFY** task is in DONE section before starting new task
 
 ## progress.txt Format
 


### PR DESCRIPTION
## Summary
- Fixed critical issue where tasks were completed (PRs merged) but not moved to DONE in backlog.md

## Problem
Tasks were being merged successfully, but the backlog.md file wasn't being updated. This caused:
- Completed tasks showing as "TODO" in backlog
- State drift between actual work and tracked state
- Confusion about what's done vs pending

## Root Cause
Step 7 (Finalize) in the algorithm wasn't emphasized enough. The model was merging PRs and moving on without updating the backlog.

## Solution
1. **prompt.md**: Step 7 now marked as CRITICAL with explicit verification requirement
2. **atlas-integration-flow skill**: Added "CRITICAL: Update Backlog After Merge" section
3. **atlas-state skill**: Added verification rules - must confirm task in DONE before starting next

## Test plan
- [ ] Run Atlas session and verify backlog is updated after each PR merge
- [ ] Verify tasks appear in DONE section with correct date and PR number

🤖 Generated with [Claude Code](https://claude.com/claude-code)