### PR TITLE
fix: remove jq dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-02-04
+
+### Changed
+- **Removed jq dependency**: `atlas resume` now uses bash-native `awk` for JSON parsing
+- No external dependencies required beyond core Unix tools (awk is POSIX standard)
+- Integration session cleanup also uses awk instead of jq
+
 ## [2.1.0] - 2026-02-04
 
 ### Added

--- a/atlas.sh
+++ b/atlas.sh
@@ -259,13 +259,10 @@ GITIGNORE
             exit 1
         fi
 
-        # Verificar jq disponible
-        command -v jq &>/dev/null || { echo "Error: 'jq' required for session management."; exit 1; }
-
-        # Leer session data
-        SESSION_BRANCH=$(jq -r '.branch' "$SESSION_FILE" 2>/dev/null)
-        SESSION_PR=$(jq -r '.pr_number' "$SESSION_FILE" 2>/dev/null)
-        SESSION_NAME=$(jq -r '.session_name' "$SESSION_FILE" 2>/dev/null)
+        # Leer session data (parsing bash puro)
+        SESSION_BRANCH=$(awk -F'"' '/"branch"/ {print $4; exit}' "$SESSION_FILE" 2>/dev/null)
+        SESSION_PR=$(awk -F'"' '/"pr_number"/ {print $4; exit}' "$SESSION_FILE" 2>/dev/null)
+        SESSION_NAME=$(awk -F'"' '/"session_name"/ {print $4; exit}' "$SESSION_FILE" 2>/dev/null)
 
         # Validar datos
         [[ -z "$SESSION_PR" || "$SESSION_PR" == "null" ]] && { echo "❌ Invalid session file: missing pr_number"; exit 1; }
@@ -539,13 +536,13 @@ elif [[ -d "$PROJECT_DIR/.git" ]]; then
     git pull origin "$DEFAULT_BRANCH" 2>/dev/null || echo "   ⚠️  Could not pull (offline or no remote)"
 
     # Check for merged integration session and cleanup
-    if [[ -f ".atlas/integration-session.json" ]] && command -v jq &>/dev/null; then
-        SESSION_PR=$(jq -r '.pr_number' .atlas/integration-session.json 2>/dev/null)
+    if [[ -f ".atlas/integration-session.json" ]]; then
+        SESSION_PR=$(awk -F'"' '/"pr_number"/ {print $4; exit}' .atlas/integration-session.json 2>/dev/null)
         if [[ -n "$SESSION_PR" && "$SESSION_PR" != "null" ]]; then
             PR_STATE=$(gh pr view "$SESSION_PR" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
             if [[ "$PR_STATE" == "MERGED" ]]; then
                 echo "   🧹 Cleaning up merged integration session (PR #$SESSION_PR)..."
-                OLD_BRANCH=$(jq -r '.branch' .atlas/integration-session.json 2>/dev/null)
+                OLD_BRANCH=$(awk -F'"' '/"branch"/ {print $4; exit}' .atlas/integration-session.json 2>/dev/null)
                 [[ -n "$OLD_BRANCH" ]] && git branch -D "$OLD_BRANCH" 2>/dev/null || true
                 rm -f .atlas/integration-session.json
                 echo "   ✓ Cleaned up. New session will be created."


### PR DESCRIPTION
## Summary
- Removed jq dependency from Atlas
- Use bash-native awk for JSON parsing (POSIX standard)
- Simpler installation, fewer dependencies

## Changes
- `atlas resume`: Parse `.atlas/integration-session.json` with awk
- Session cleanup: Parse integration session with awk
- `CHANGELOG.md`: Version 2.1.1

## Why awk works
- JSON format is controlled by us (simple, predictable)
- Values are safe: branch names, PR numbers (no special chars)
- Awk is POSIX standard (Linux, macOS, BSD)

## Test Plan
- [x] awk parsing extracts correct fields
- [ ] Manual test: `atlas resume` works without jq installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)