### PR TITLE
fix: correct Codex CLI flag from --full-auto to --yolo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-02-04
+
+### Fixed
+- **Codex flag syntax**: Changed from incorrect `--full-auto` to `--yolo` (official bypass flag)
+- Codex now runs with full permission bypass in both plan and execution modes
+
 ## [2.2.0] - 2026-02-04
 
 ### Added

--- a/atlas.sh
+++ b/atlas.sh
@@ -7,7 +7,7 @@ PROJECT_NAME="$(basename "$PROJECT_DIR")"
 NOTIFY_TELEGRAM="${ATLAS_NOTIFY_TELEGRAM:-true}"
 
 # Atlas version
-ATLAS_VERSION="2.2.0"
+ATLAS_VERSION="2.2.1"
 
 # AI Provider configuration (claudecode | opencode)
 # Priority: --cli flag > ATLAS_CLI env var > default (claudecode)
@@ -253,7 +253,7 @@ GITIGNORE
             export OPENCODE_PERMISSION='{"*":"allow"}'
             opencode run --agent plan "$PLAN_PROMPT"
         elif [[ "$ATLAS_CLI" == "codex" ]]; then
-            codex exec --full-auto "$PLAN_PROMPT"
+            codex exec --yolo "$PLAN_PROMPT"
         else
             claude --dangerously-skip-permissions "$PLAN_PROMPT"
         fi
@@ -978,7 +978,7 @@ $PROMPT_CONTENT"
             export OPENCODE_PERMISSION='{"*":"allow"}'
             OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" opencode run --agent build "$(cat "$PROMPT_FILE_TMP")" 2>&1) || true
         elif [[ "$ATLAS_CLI" == "codex" ]]; then
-            OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" codex exec --full-auto "$(cat "$PROMPT_FILE_TMP")" 2>&1) || true
+            OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" codex exec --yolo "$(cat "$PROMPT_FILE_TMP")" 2>&1) || true
         else
             OUTPUT=$(run_with_timeout "$TIMEOUT_SECONDS" claude --dangerously-skip-permissions -p < "$PROMPT_FILE_TMP" 2>&1) || true
         fi


### PR DESCRIPTION
## Summary

Fix incorrect Codex CLI flag. The correct flag for bypassing permissions is `--yolo`, not `--full-auto`.

## Problem

The initial implementation used `--full-auto` which doesn't exist in Codex CLI. According to [official docs](https://developers.openai.com/codex/cli/reference/):

```
--dangerously-bypass-approvals-and-sandbox, --yolo
    Run every command without approvals or sandboxing.
```

## Changes

- ✅ Plan mode: `codex exec --yolo "$PLAN_PROMPT"`
- ✅ Main loop: `codex exec --yolo "$(cat "$PROMPT_FILE_TMP")"`
- ✅ Bump version to 2.2.1

## Equivalents

- Claude Code: `--dangerously-skip-permissions`
- OpenCode: `OPENCODE_PERMISSION='{"*":"allow"}'`
- Codex: `--yolo`

🤖 Generated with Claude Code