### PR TITLE
docs: audit README and fix command accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ atlas
 | `atlas review [--dry-run]` | Audit and fix issues from Atlas iterations |
 | `atlas resume [N]` | Resume interrupted integration session |
 | `atlas clean [--all]` | Clean runtime artifacts from `.atlas/` |
-| `atlas [--cli <provider>] <command>` | Run any command with a specific AI provider |
+| `atlas [--cli <provider>] [command or iterations]` | Run any command (or iteration loop) with a specific AI provider |
 | `atlas update` | Update Atlas from GitHub (preserves your project data) |
 | `atlas help` | Show help |
 
@@ -222,7 +222,7 @@ for each iteration:
 
 ## Project Structure
 
-After `atlas init`:
+After `atlas init` (`specs/` appears after `atlas plan`):
 
 ```
 your-project/
@@ -233,7 +233,7 @@ your-project/
     ├── guardrails.md      # Rules from past errors
     ├── errors.log         # Failure log
     ├── activity.log       # Run history
-    ├── specs/             # Feature specs (from atlas plan)
+    ├── specs/             # Feature specs (created by atlas plan)
     └── runs/              # Iteration logs
 ```
 


### PR DESCRIPTION
## What I reviewed
- Full `README.md` against current `atlas.sh` command parser/behavior
- Verified documented commands via isolated CLI smoke test with mocked providers

## Fixes applied
1. Clarified command table entry to reflect actual parser behavior:
   - from: `atlas [--cli <provider>] <command>`
   - to: `atlas [--cli <provider>] [command or iterations]`
2. Corrected project structure section accuracy:
   - documented that `specs/` appears after `atlas plan` (not immediately after `atlas init`)

## Validation
- Ran command smoke test covering: `help`, `init`, `clean`, `clean --all`, `review --dry-run`, `plan`, `resume 5` (expected no-session failure path)
- Result: `OK`

No changelog changes included (docs-only PR as requested).
