### PR TITLE
fix: run codex review quietly in atlas

### DIFF
--- a/atlas.sh
+++ b/atlas.sh
@@ -458,7 +458,20 @@ GITIGNORE
             export OPENCODE_PERMISSION='{"*":"allow"}'
             opencode run --agent review "$REVIEW_PROMPT"
         elif [[ "$ATLAS_CLI" == "codex" ]]; then
-            codex exec --yolo "$REVIEW_PROMPT"
+            mkdir -p "$RUNS_DIR"
+            REVIEW_RUN_TAG="$(date +%Y%m%d-%H%M%S)-$$"
+            REVIEW_LOG_FILE="$RUNS_DIR/review-$REVIEW_RUN_TAG.log"
+            REVIEW_LAST_MESSAGE_FILE="$RUNS_DIR/review-$REVIEW_RUN_TAG-last-message.txt"
+
+            if codex exec --yolo -o "$REVIEW_LAST_MESSAGE_FILE" "$REVIEW_PROMPT" > "$REVIEW_LOG_FILE" 2>&1; then
+                echo "✅ Codex review completed (non-interactive mode)"
+                echo "   Log: $REVIEW_LOG_FILE"
+            else
+                echo "❌ Codex review failed"
+                echo "   Log: $REVIEW_LOG_FILE"
+                tail -n 40 "$REVIEW_LOG_FILE" 2>/dev/null || true
+                exit 1
+            fi
         else
             claude --dangerously-skip-permissions "$REVIEW_PROMPT"
         fi


### PR DESCRIPTION
## Qué estaba pasando
`atlas review --cli codex` estaba ejecutando `codex exec` directo a stdout/stderr.
Aunque es no interactivo, Codex imprime trazas de sesión (banner, reasoning, pasos), lo que se ve como “chat interactivo”.

## Fix aplicado
- Mantengo `codex exec` en modo no interactivo.
- Redirijo toda salida de Codex a archivo de log en `.atlas/runs/`.
- Muestro en consola solo un estado limpio de Atlas (éxito/error + ruta de log).
- En error, imprimo tail del log para diagnóstico rápido.

## Validación
- `bash -n atlas.sh`
- Test aislado con Codex mockeado verificando:
  - no se filtra salida “chatty” a consola
  - se crea log de review
  - el log sí contiene la salida completa de Codex
