### PR TITLE
chore: release v3.1.0 - test trusted publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-02-14
+
+### Changed
+- **CI: Trusted Publishing**: NPM publish via OIDC (no tokens needed)
+- **Removed GitHub repo/homepage links** from NPM package page
+- **README**: Install and Update sections together at the top
+
 ## [3.0.0] - 2026-02-13
 
 ### Changed

--- a/atlas.sh
+++ b/atlas.sh
@@ -14,7 +14,7 @@ PROJECT_NAME="$(basename "$PROJECT_DIR")"
 NOTIFY_TELEGRAM="${ATLAS_NOTIFY_TELEGRAM:-true}"
 
 # Atlas version
-ATLAS_VERSION="3.0.0"
+ATLAS_VERSION="3.1.0"
 
 # AI Provider configuration (claudecode | opencode | codex)
 # Priority: --cli flag > ATLAS_CLI env var > default (claudecode)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jxtools/atlas",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Autonomous Task Loop Agent System - automates task processing using AI coding agents",
   "bin": {
     "atlas": "atlas.sh"


### PR DESCRIPTION
## Summary

- Version bump to 3.1.0 to test NPM Trusted Publishing pipeline
- Includes CI and README improvements from previous PRs

## Test plan

- [ ] Merge triggers GitHub Action
- [ ] Action detects 3.1.0 != 3.0.0 (published)
- [ ] OIDC auth with NPM succeeds
- [ ] `npm view @jxtools/atlas version` returns 3.1.0