### PR TITLE
fix: restore repository.url for NPM provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2026-02-14
+
+### Fixed
+- **Provenance publishing**: Restored `repository.url` required by NPM provenance verification
+
 ## [3.1.0] - 2026-02-14
 
 ### Changed
 - **CI: Trusted Publishing**: NPM publish via OIDC (no tokens needed)
-- **Removed GitHub repo/homepage links** from NPM package page
+- **Removed homepage link** from NPM package page
 - **README**: Install and Update sections together at the top
 
 ## [3.0.0] - 2026-02-13

--- a/atlas.sh
+++ b/atlas.sh
@@ -14,7 +14,7 @@ PROJECT_NAME="$(basename "$PROJECT_DIR")"
 NOTIFY_TELEGRAM="${ATLAS_NOTIFY_TELEGRAM:-true}"
 
 # Atlas version
-ATLAS_VERSION="3.1.0"
+ATLAS_VERSION="3.1.1"
 
 # AI Provider configuration (claudecode | opencode | codex)
 # Priority: --cli flag > ATLAS_CLI env var > default (claudecode)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jxtools/atlas",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Autonomous Task Loop Agent System - automates task processing using AI coding agents",
   "bin": {
     "atlas": "atlas.sh"
@@ -35,6 +35,10 @@
     "automation",
     "backlog"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/juancruzrossi/atlas"
+  },
   "license": "ISC",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

NPM `--provenance` requires `repository.url` in package.json to match the GitHub repo origin. The 3.1.0 publish failed with:

> Error verifying sigstore provenance bundle: package.json "repository.url" is "", expected to match "https://github.com/juancruzrossi/atlas"

This restores the `repository` field (required for trusted publishing) and bumps to 3.1.1.

## Test plan

- [ ] Action publishes 3.1.1 to NPM via Trusted Publishing
- [ ] `npm view @jxtools/atlas version` returns 3.1.1