### PR TITLE
fix: restore repo URL for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,4 @@ jobs:
 
       - name: Publish to NPM
         if: steps.check.outputs.skip == 'false'
-        run: npm publish --access public
+        run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.2] - 2026-02-14
+## [3.1.3] - 2026-02-14
 
 ### Fixed
-- **Remove repository URL from NPM**: Drop `--provenance` flag so `repository.url` is no longer required in package.json
+- **CI pipeline stabilized**: Trusted Publishing requires `repository.url` and `--provenance`; both restored
 - **README Update section**: Show `atlas update` instead of raw npm command
 
 ## [3.1.1] - 2026-02-14

--- a/atlas.sh
+++ b/atlas.sh
@@ -14,7 +14,7 @@ PROJECT_NAME="$(basename "$PROJECT_DIR")"
 NOTIFY_TELEGRAM="${ATLAS_NOTIFY_TELEGRAM:-true}"
 
 # Atlas version
-ATLAS_VERSION="3.1.2"
+ATLAS_VERSION="3.1.3"
 
 # AI Provider configuration (claudecode | opencode | codex)
 # Priority: --cli flag > ATLAS_CLI env var > default (claudecode)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jxtools/atlas",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Autonomous Task Loop Agent System - automates task processing using AI coding agents",
   "bin": {
     "atlas": "atlas.sh"
@@ -35,6 +35,10 @@
     "automation",
     "backlog"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/juancruzrossi/atlas"
+  },
   "license": "ISC",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Trusted Publishing requires repository.url. Bump to 3.1.3.