### PR TITLE
fix: preserve npm registry in update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Atlas is an **A**utonomous **T**ask **L**oop **A**gent **S**ystem that processes
 npm install -g @jxtools/atlas
 ```
 
+If your environment requires an explicit npm registry:
+
+```bash
+npm install -g @jxtools/atlas --registry https://registry.npmjs.org/
+```
+
 ## Update
 
 ```bash

--- a/atlas.sh
+++ b/atlas.sh
@@ -36,7 +36,34 @@ json_get() {
 
 # Atlas version (read from package.json, fallback to hardcoded)
 ATLAS_VERSION=$(json_get "version" "$ATLAS_HOME/package.json")
-[[ -z "$ATLAS_VERSION" ]] && ATLAS_VERSION="3.2.5"
+[[ -z "$ATLAS_VERSION" ]] && ATLAS_VERSION="3.2.6"
+
+atlas_saved_registry() {
+    local registry_file="$ATLAS_HOME/.npm-registry"
+    [[ ! -f "$registry_file" ]] && return
+    awk 'NF { print; exit }' "$registry_file"
+}
+
+atlas_npm_registry() {
+    if [[ -n "${npm_config_registry:-}" ]]; then
+        printf '%s\n' "$npm_config_registry"
+        return
+    fi
+
+    if [[ -n "${NPM_CONFIG_REGISTRY:-}" ]]; then
+        printf '%s\n' "$NPM_CONFIG_REGISTRY"
+        return
+    fi
+
+    local saved_registry
+    saved_registry="$(atlas_saved_registry)"
+    if [[ -n "$saved_registry" ]]; then
+        printf '%s\n' "$saved_registry"
+        return
+    fi
+
+    npm config get registry 2>/dev/null || true
+}
 
 # AI Provider configuration (claudecode | opencode | codex)
 # Priority: --cli flag > ATLAS_CLI env var > default (claudecode)
@@ -425,16 +452,23 @@ GITIGNORE
         exit 0
         ;;
     update)
+        registry="$(atlas_npm_registry)"
+        update_command="npm update -g @jxtools/atlas"
+        latest_command="npm view @jxtools/atlas version"
+        if [[ -n "$registry" ]]; then
+            update_command="$update_command --registry $registry"
+            latest_command="$latest_command --registry $registry"
+        fi
         echo "Atlas is now distributed via NPM."
         echo ""
         echo "To update, run:"
-        echo "  npm update -g @jxtools/atlas"
+        echo "  $update_command"
         echo ""
         echo "To check your current version:"
         echo "  atlas --version"
         echo ""
         echo "To check the latest available version:"
-        echo "  npm view @jxtools/atlas version"
+        echo "  $latest_command"
         exit 0
         ;;
     plan)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jxtools/atlas",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jxtools/atlas",
-      "version": "3.2.5",
+      "version": "3.2.6",
       "hasInstallScript": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jxtools/atlas",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Autonomous Task Loop Agent System - automates task processing using AI coding agents",
   "bin": {
     "atlas": "atlas.sh"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -9,9 +9,24 @@ const atlasHome = resolve(__dirname, '..')
 const skillsDir = join(atlasHome, 'skills')
 const homeDir = process.env.HOME || process.env.USERPROFILE
 const MANIFEST_NAME = '.atlas-skills-manifest.json'
+const REGISTRY_FILE = join(atlasHome, '.npm-registry')
 
 function warn(message) {
   process.stderr.write(`Warning: ${message}\n`)
+}
+
+function resolveRegistry(env) {
+  const explicit = env.npm_config_registry || env.NPM_CONFIG_REGISTRY
+  if (explicit) return explicit
+
+  try {
+    return execSync('npm config get registry', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return ''
+  }
 }
 
 if (!existsSync(skillsDir)) process.exit(0)
@@ -21,6 +36,15 @@ const skillDirs = readdirSync(skillsDir).filter(d =>
 )
 
 if (skillDirs.length === 0) process.exit(0)
+
+const registry = resolveRegistry(process.env)
+if (registry) {
+  try {
+    writeFileSync(REGISTRY_FILE, `${registry}\n`)
+  } catch (error) {
+    warn(`could not persist npm registry: ${error.message}`)
+  }
+}
 
 const providers = []
 


### PR DESCRIPTION
## Summary
- persist the npm registry used at install time
- make atlas update print npm commands with that same registry
- document the explicit --registry install fallback

## Testing
- npm test
- npm_config_registry='https://registry.npmjs.org/' node scripts/postinstall.js && bash ./atlas.sh update
